### PR TITLE
Change CUDA-wrappers to cudawrappers in many files

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,7 +14,7 @@
 Clone and verify
 ```
 cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
-git clone https://github.com/nlesc-recruit/CUDA-wrappers .
+git clone https://github.com/nlesc-recruit/cudawrappers .
 git checkout <this-branch>
 ```
 -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,5 +21,5 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - First release with existing code.
 
-[Unreleased]: https://github.com/nlesc-recruit/CUDA-wrappers/compare/0.1.0...HEAD
-[0.1.0]: https://github.com/nlesc-recruit/CUDA-wrappers/releases/tag/0.1.0
+[Unreleased]: https://github.com/nlesc-recruit/cudawrappers/compare/0.1.0...HEAD
+[0.1.0]: https://github.com/nlesc-recruit/cudawrappers/releases/tag/0.1.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -52,7 +52,7 @@ identifiers:
   - type: doi
     value: 10.5281/zenodo.6076447
     description: The concept doi for all versions of the software.
-repository-code: 'https://github.com/nlesc-recruit/CUDA-wrappers'
+repository-code: 'https://github.com/nlesc-recruit/cudawrappers'
 abstract: C++ Wrappers for the CUDA Driver API.
 keywords:
   - CUDA

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,12 +13,12 @@ The sections below outline the steps in each case.
 
 ## You have a question
 
-1. use the search functionality [here](https://github.com/nlesc-recruit/CUDA-wrappers/issues) to see if someone already filed the same issue;
+1. use the search functionality [here](https://github.com/nlesc-recruit/cudawrappers/issues) to see if someone already filed the same issue;
 2. if your issue search did not yield any relevant results, make a new issue.
 
 ## You think you may have found a bug
 
-1. use the search functionality [here](https://github.com/nlesc-recruit/CUDA-wrappers/issues) to see if someone already filed the same issue;
+1. use the search functionality [here](https://github.com/nlesc-recruit/cudawrappers/issues) to see if someone already filed the same issue;
 1. if your issue search did not yield any relevant results, make a new issue, making sure to provide enough information to the rest of the community to understand the cause and context of the problem. Depending on the issue, you may want to include:
     - the version number that is causing your problem;
     - some identifying information (name and version number) for dependencies you're using;
@@ -34,7 +34,7 @@ The sections below outline the steps in each case.
 1. add your own tests (if necessary);
 1. update or expand the documentation;
 1. update the `CHANGELOG.md` file with change;
-1. push your feature branch to (your fork of) the https://github.com/nlesc-recruit/CUDA-wrappers repository on GitHub;
+1. push your feature branch to (your fork of) the https://github.com/nlesc-recruit/cudawrappers repository on GitHub;
 1. create the pull request, e.g. following the instructions [here](https://help.github.com/articles/creating-a-pull-request/).
 
 In case you feel like you've made a valuable contribution, but you don't know how to write or run tests for it, or how to generate the documentation: don't let this discourage you from making the pull request; we can help you! Just go ahead and submit the pull request, but keep in mind that you might be asked to append additional commits to your pull request.

--- a/README.dev.md
+++ b/README.dev.md
@@ -10,8 +10,8 @@ Before you can do development work on the template, you'll need to check out a l
 
 ```shell
 cd <where you keep your GitHub repositories>
-git clone https://github.com/nlesc-recruit/CUDA-wrappers.git
-cd CUDA-wrappers
+git clone https://github.com/nlesc-recruit/cudawrappers.git
+cd cudawrappers
 ```
 
 ### Prepare your environment
@@ -42,5 +42,5 @@ cd CUDA-wrappers
 
 ### GitHub
 
-1. Make sure that the GitHub-Zenodo integration is enabled for https://github.com/nlesc-recruit/CUDA-wrappers
-1. Go to https://github.com/nlesc-recruit/CUDA-wrappers/releases and click `Draft a new release`
+1. Make sure that the GitHub-Zenodo integration is enabled for https://github.com/nlesc-recruit/cudawrappers
+1. Go to https://github.com/nlesc-recruit/cudawrappers/releases and click `Draft a new release`

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![DOI](https://zenodo.org/badge/424944643.svg)](https://zenodo.org/badge/latestdoi/424944643)
 [![cii badge](https://bestpractices.coreinfrastructure.org/projects/5686/badge)](https://bestpractices.coreinfrastructure.org/projects/5686)
 [![fair-software.eu](https://img.shields.io/badge/fair--software.eu-%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8B%20%20%E2%97%8F%20%20%E2%97%8F-orange)](https://fair-software.eu)
-[![Codacy Badge](https://app.codacy.com/project/badge/Grade/bfda629ae58147fd8574a02d0b6f3118)](https://www.codacy.com/gh/nlesc-recruit/cudawrappers/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=nlesc-recruit/cudawrappers&amp;utm_campaign=Badge_Grade)
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/d38b0338fda24733ab41a64915af8248)](https://www.codacy.com/gh/nlesc-recruit/cudawrappers/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=nlesc-recruit/cudawrappers&amp;utm_campaign=Badge_Grade)
 [![citation metadata](https://github.com/nlesc-recruit/cudawrappers/actions/workflows/cffconvert.yml/badge.svg)](https://github.com/nlesc-recruit/cudawrappers/actions/workflows/cffconvert.yml)
 
 # cudawrappers

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-[![github url](https://img.shields.io/badge/github-url-000.svg?logo=github&labelColor=gray&color=blue)](https://github.com/nlesc-recruit/CUDA-wrappers)
-[![github license badge](https://img.shields.io/github/license/nlesc-recruit/CUDA-wrappers)](https://github.com/nlesc-recruit/CUDA-wrappers)
+[![github url](https://img.shields.io/badge/github-url-000.svg?logo=github&labelColor=gray&color=blue)](https://github.com/nlesc-recruit/cudawrappers)
+[![github license badge](https://img.shields.io/github/license/nlesc-recruit/cudawrappers)](https://github.com/nlesc-recruit/cudawrappers)
 [![DOI](https://zenodo.org/badge/424944643.svg)](https://zenodo.org/badge/latestdoi/424944643)
 [![cii badge](https://bestpractices.coreinfrastructure.org/projects/5686/badge)](https://bestpractices.coreinfrastructure.org/projects/5686)
 [![fair-software.eu](https://img.shields.io/badge/fair--software.eu-%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8B%20%20%E2%97%8F%20%20%E2%97%8F-orange)](https://fair-software.eu)
-[![Codacy Badge](https://app.codacy.com/project/badge/Grade/bfda629ae58147fd8574a02d0b6f3118)](https://www.codacy.com/gh/nlesc-recruit/CUDA-wrappers/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=nlesc-recruit/CUDA-wrappers&amp;utm_campaign=Badge_Grade)
-[![citation metadata](https://github.com/nlesc-recruit/CUDA-wrappers/actions/workflows/cffconvert.yml/badge.svg)](https://github.com/nlesc-recruit/CUDA-wrappers/actions/workflows/cffconvert.yml)
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/bfda629ae58147fd8574a02d0b6f3118)](https://www.codacy.com/gh/nlesc-recruit/cudawrappers/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=nlesc-recruit/cudawrappers&amp;utm_campaign=Badge_Grade)
+[![citation metadata](https://github.com/nlesc-recruit/cudawrappers/actions/workflows/cffconvert.yml/badge.svg)](https://github.com/nlesc-recruit/cudawrappers/actions/workflows/cffconvert.yml)
 
 # cudawrappers
 


### PR DESCRIPTION
**Description**

Change CUDA-wrappers to cudawrappers in many files

**Related issues**:

- #99 

**Instructions to review the pull request**

- Check that CHANGELOG.md has been updated if necessary

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/CUDA-wrappers .
git checkout <this-branch>
```
-->

Review online.

PS. Codacy badge is broken because we are debugging #98 and removed Codacy and will reinstall. Please ignore it.