### PR TITLE
Updated documentation about how to install the linters/formatters

### DIFF
--- a/README.dev.md
+++ b/README.dev.md
@@ -28,6 +28,19 @@ We use the following linters and formatters in this project:
 - [cppcheck](https://cppcheck.sourceforge.io)
 - [flawfinder](https://dwheeler.com/flawfinder/)
 
+You can install these tools as follows:
+
+```shell
+# install cppcheck, clang-tidy, clang-format from your package manager
+sudo apt install cppcheck clang-format clang-tidy
+
+# install python3 and pip
+sudo apt install python3 python3-pip
+
+# install flawfinder, cmake-format, cmake-lint from PyPI using pip
+python3 -m pip install flawfinder cmake-format cmake-lint 
+```
+
 The formatter `clang-format` will format all source files, and `cmake-format` will format all CMake-related files.
 The linters will check for errors and bugs, but also style-related issues. So run the formatters before running the linters.
 

--- a/README.dev.md
+++ b/README.dev.md
@@ -28,7 +28,7 @@ We use the following linters and formatters in this project:
 - [cppcheck](https://cppcheck.sourceforge.io)
 - [flawfinder](https://dwheeler.com/flawfinder/)
 
-You can install these tools as follows:
+You can install these tools on a Debian-like system as follows:
 
 ```shell
 # install cppcheck, clang-tidy, clang-format from your package manager
@@ -38,7 +38,7 @@ sudo apt install cppcheck clang-format clang-tidy
 sudo apt install python3 python3-pip
 
 # install flawfinder, cmake-format, cmake-lint from PyPI using pip
-python3 -m pip install flawfinder cmake-format cmake-lint 
+python3 -m pip install flawfinder cmakelang
 ```
 
 The formatter `clang-format` will format all source files, and `cmake-format` will format all CMake-related files.


### PR DESCRIPTION
**Description**

Updated the documentation about how developers can install the various linters and formatters. Instead of offering a requirements file, I opted to put the equivalent commands directly in the README.dev.md

**Related issues**:

- #90

**Instructions to review the pull request**

- Check that CHANGELOG.md has been updated if necessary

Review online by reviewing the README.dev.md section on linters
