### PR TITLE
Update clang-tidy configuration and lint only src/ and include/ files

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,47 +1,38 @@
 ---
-# Generated with clang-tidy src/* -dump-config > .clang-tidy
-Checks:          'clang-diagnostic-*,clang-analyzer-*'
-WarningsAsErrors: ''
+# Copied from https://github.com/fbaeuerlein/cpp-vscode-guide/blob/02617fe158f456d254fbebffcf6a7957198cbc5f/.clang-tidy
+# Which is under CC0 (https://github.com/fbaeuerlein/cpp-vscode-guide/blob/02617fe158f456d254fbebffcf6a7957198cbc5f/LICENSE)
+Checks:          'clang-diagnostic-*,clang-analyzer-*,cppcoreguidelines-*,modernize-*,-modernize-use-trailing-return-type'
+WarningsAsErrors: true
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false
-FormatStyle:     none
-User:            abel
+FormatStyle:     google
 CheckOptions:
-  - key:             llvm-else-after-return.WarnOnConditionVariables
-    value:           'false'
-  - key:             modernize-loop-convert.MinConfidence
-    value:           reasonable
-  - key:             modernize-replace-auto-ptr.IncludeStyle
-    value:           llvm
-  - key:             modernize-pass-by-value.IncludeStyle
-    value:           llvm
+  - key:             cert-dcl16-c.NewSuffixes
+    value:           'L;LL;LU;LLU'
+  - key:             cert-oop54-cpp.WarnOnlyIfThisHasSuspiciousField
+    value:           '0'
+  - key:             cppcoreguidelines-explicit-virtual-functions.IgnoreDestructors
+    value:           '1'
+  - key:             cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
+    value:           '1'
+  - key:             google-readability-braces-around-statements.ShortStatementLines
+    value:           '1'
+  - key:             google-readability-function-size.StatementThreshold
+    value:           '800'
   - key:             google-readability-namespace-comments.ShortNamespaceLines
     value:           '10'
   - key:             google-readability-namespace-comments.SpacesBeforeComments
     value:           '2'
-  - key:             cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
-    value:           'true'
-  - key:             google-readability-braces-around-statements.ShortStatementLines
-    value:           '1'
-  - key:             cert-oop54-cpp.WarnOnlyIfThisHasSuspiciousField
-    value:           'false'
   - key:             modernize-loop-convert.MaxCopySize
     value:           '16'
-  - key:             cert-dcl16-c.NewSuffixes
-    value:           'L;LL;LU;LLU'
-  - key:             cert-str34-c.DiagnoseSignedUnsignedCharComparisons
-    value:           'false'
-  - key:             cppcoreguidelines-explicit-virtual-functions.IgnoreDestructors
-    value:           'true'
-  - key:             modernize-use-nullptr.NullMacros
-    value:           'NULL'
-  - key:             llvm-qualified-auto.AddConstToQualified
-    value:           'false'
+  - key:             modernize-loop-convert.MinConfidence
+    value:           reasonable
   - key:             modernize-loop-convert.NamingStyle
     value:           CamelCase
-  - key:             llvm-else-after-return.WarnOnUnfixable
-    value:           'false'
-  - key:             google-readability-function-size.StatementThreshold
-    value:           '800'
+  - key:             modernize-pass-by-value.IncludeStyle
+    value:           llvm
+  - key:             modernize-replace-auto-ptr.IncludeStyle
+    value:           llvm
+  - key:             modernize-use-nullptr.NullMacros
+    value:           'NULL'
 ...
-

--- a/cmake/linter-tools.cmake
+++ b/cmake/linter-tools.cmake
@@ -4,7 +4,7 @@
 # Ref:
 # https://stackoverflow.com/questions/32280717/cmake-clang-tidy-or-other-script-as-custom-target
 
-file(GLOB_RECURSE ALL_SOURCE_FILES *.cpp *.hpp)
+file(GLOB_RECURSE ALL_SOURCE_FILES src/*.cpp include/*.hpp)
 file(GLOB_RECURSE ALL_CMAKE_LISTS CMakeLists.txt *.cmake)
 
 add_custom_target(clang-format COMMAND clang-format -i ${ALL_SOURCE_FILES})


### PR DESCRIPTION
**Description**

First, I updated clang-tidy's configuration.
The old configuration essentially ran no (significant) checks. The new one was taken from https://github.com/fbaeuerlein/cpp-vscode-guide (CC0 License).

This may lead to differences between clang-format and clang-lint, but this is for another issue.

One alternative to using the linked repo is to use `clang-tidy -checks '*' -dump-config > .clang-tidy` and use **all** checks. I chose not to do it because the configuration will have 650 lines and tens of thousands of errors are returned by clang-tidy.

Second, `clang-tidy` needs to be able to compile the code, so I am linting only `src` and `include` files because the files in `tests` fail to build. #116 needs to be done beforing linting `tests` with `clang-tidy`.

**Related issues**:

- #89

**Instructions to review the pull request**

- Check that CHANGELOG.md has been updated if necessary

Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```

<!--
Review online.
-->
