### PR TITLE
Generate separate objects for cu and nvrtc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,8 @@ set(SOURCE_FILES src/cu.cpp src/nvrtc.cpp)
 include_directories(./include/)
 include_directories(${CUDAToolkit_INCLUDE_DIRS})
 
+add_library(cudawrappers_cu SHARED src/cu.cpp)
+add_library(cudawrappers_nvrtc SHARED src/nvrtc.cpp)
 add_library(cudawrappers SHARED ${SOURCE_FILES})
 
 # Including linters rules


### PR DESCRIPTION
**Description**

Generate separate objects for cu and nvrtc. Namely `libcudawrappers_cu.so` and `libcudawrappers_nvrtc.so`.

**Related issues**:

- #95 

**Instructions to review the pull request**

- Check that CHANGELOG.md has been updated if necessary


Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```
- Look into `build` for the `.so` files.

<!--
Review online.
-->
