### PR TITLE
Add make command to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,6 +17,7 @@ cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
 git clone https://github.com/nlesc-recruit/cudawrappers .
 git checkout <this-branch>
 cmake -S . -B build
+make -C build
 make -C build format # Nothing should change
 make -C build lint # linting is broken until we fix the issues (see #92)
 ```


### PR DESCRIPTION
**Description**

Add make command to PR template.

**Related issues**:

- None

**Instructions to review the pull request**

- Check that CHANGELOG.md has been updated if necessary

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```
-->

Review online.
