### PR TITLE
Fix missing linters cppcheck and flawfinder

### DIFF
--- a/cmake/linter-tools.cmake
+++ b/cmake/linter-tools.cmake
@@ -13,6 +13,10 @@ set(INCLUDE_DIRECTORIES -I../include/ -I${CUDAToolkit_INCLUDE_DIRS})
 add_custom_target(clang-tidy COMMAND clang-tidy ${ALL_SOURCE_FILES} --
                                      -std=c++11 ${INCLUDE_DIRECTORIES})
 
+add_custom_target(cppcheck COMMAND cppcheck ${ALL_SOURCE_FILES})
+
+add_custom_target(flawfinder COMMAND flawfinder ${ALL_SOURCE_FILES})
+
 add_custom_target(cmake-format COMMAND cmake-format --in-place
                                        ${ALL_CMAKE_LISTS})
 


### PR DESCRIPTION
**Description**

I must have removed cppcheck and flawfinder from `make lint` in some merge. This returns them.

**Related issues**:

- None

**Instructions to review the pull request**

- Check that CHANGELOG.md has been updated if necessary


Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```


<!--
Review online.
-->
