### PR TITLE
Fix include in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,8 @@ project(
   DESCRIPTION "C++ Wrappers for the CUDA Driver API"
   VERSION 0.3.0
   HOMEPAGE_URL https://github.com/nlesc-recruit/cudawrappers
-  LANGUAGES CUDA CXX)
+  LANGUAGES CXX)
+
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_BUILD_TYPE "Release")
 
@@ -18,10 +19,14 @@ endif()
 
 set(SOURCE_FILES src/cu.cpp src/nvrtc.cpp)
 
-include_directories(./include/)
-include_directories(${CUDAToolkit_INCLUDE_DIRS})
-
 add_library(cudawrappers SHARED ${SOURCE_FILES})
+
+target_include_directories(
+  cudawrappers
+  PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include"
+  PRIVATE ${CUDAToolkit_INCLUDE_DIRS})
+
+target_link_libraries(cudawrappers PUBLIC CUDA::cuda_driver CUDA::nvrtc)
 
 # Including linters rules
 include(cmake/linter-tools.cmake)


### PR DESCRIPTION
**Description**

<!-- Description of PR -->

Update the include statement in CMakeLists.txt so this can be used in the git submodule example.

**Related issues**:

Closes #134

**Instructions to review the pull request**

- Check that CHANGELOG.md has been updated if necessary

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```
-->

<!--
Review online.
-->
