### PR TITLE
Fix documentation build

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
-breathe==4.33.1
-exhale==0.3.1
-Sphinx==4.4.0
-sphinx-rtd-theme==1.0.0
-myst-parser==0.17.0
+breathe
+exhale
+Sphinx
+sphinx-rtd-theme
+myst-parser


### PR DESCRIPTION
**Description**

<!-- Description of PR -->

The documentation build is failing: https://readthedocs.org/projects/cudawrappers/builds/16740786/

This pull request fixes the problem by unpinning the documentation dependencies.


**Instructions to review the pull request**

Check that the documentation on readthedocs builds successfully.

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```
-->

<!--
Review online.
-->
