### PR TITLE
Address linter issues in cu and nvrtc libraries

### DIFF
--- a/include/cu.hpp
+++ b/include/cu.hpp
@@ -66,9 +66,9 @@ class Wrapper {
     other._obj = 0;
   }
 
-  Wrapper<T>(T &obj) : _obj(obj) {}
+  explicit Wrapper<T>(T &obj) : _obj(obj) {}
 
-  T _obj;
+  T _obj{};
   std::shared_ptr<T> manager;
 };
 
@@ -302,7 +302,8 @@ class Array : public Wrapper<CUarray> {
 
 class Source {
  public:
-  Source(const char *input_file_name) : input_file_name(input_file_name) {}
+  explicit Source(const char *input_file_name)
+      : input_file_name(input_file_name) {}
 
   void compile(const char *ptx_name, const char *compile_options = nullptr);
 
@@ -312,7 +313,7 @@ class Source {
 
 class Module : public Wrapper<CUmodule> {
  public:
-  Module(const char *file_name) {
+  explicit Module(const char *file_name) {
 #if defined TEGRA_QUIRKS  // cuModuleLoad broken on Jetson TX1
     std::ifstream file(file_name);
     std::string program((std::istreambuf_iterator<char>(file)),
@@ -327,7 +328,7 @@ class Module : public Wrapper<CUmodule> {
     });
   }
 
-  Module(const void *data) {
+  explicit Module(const void *data) {
     checkCudaCall(cuModuleLoadData(&_obj, data));
     manager = std::shared_ptr<CUmodule>(new CUmodule(_obj), [](CUmodule *ptr) {
       cuModuleUnload(*ptr);
@@ -335,7 +336,7 @@ class Module : public Wrapper<CUmodule> {
     });
   }
 
-  Module(CUmodule &module) : Wrapper(module) {}
+  explicit Module(CUmodule &module) : Wrapper(module) {}
 
 #if 0
       TexRef getTexRef(const char *name) const
@@ -359,7 +360,7 @@ class Function : public Wrapper<CUfunction> {
     checkCudaCall(cuModuleGetFunction(&_obj, module, name));
   }
 
-  Function(CUfunction &function) : Wrapper(function) {}
+  explicit Function(CUfunction &function) : Wrapper(function) {}
 
   int getAttribute(CUfunction_attribute attribute) {
     int value{};
@@ -382,7 +383,7 @@ class Event : public Wrapper<CUevent> {
     });
   }
 
-  Event(CUevent &event) : Wrapper(event) {}
+  explicit Event(CUevent &event) : Wrapper(event) {}
 
   float elapsedTime(const Event &start) const {
     float ms{};
@@ -413,7 +414,7 @@ class Stream : public Wrapper<CUstream> {
     });
   }
 
-  Stream(CUstream stream) : Wrapper<CUstream>(stream) {}
+  explicit Stream(CUstream stream) : Wrapper<CUstream>(stream) {}
 
   void memcpyHtoDAsync(CUdeviceptr devPtr, const void *hostPtr, size_t size) {
     checkCudaCall(cuMemcpyHtoDAsync(devPtr, hostPtr, size, _obj));

--- a/include/nvrtc.hpp
+++ b/include/nvrtc.hpp
@@ -14,7 +14,7 @@
 namespace nvrtc {
 class Error : public std::exception {
  public:
-  Error(nvrtcResult result) : _result(result) {}
+  explicit Error(nvrtcResult result) : _result(result) {}
 
   const char *what() const noexcept override;
 
@@ -39,7 +39,7 @@ class Program {
                                       numHeaders, headers, includeNames));
   }
 
-  Program(const std::string &filename) {
+  explicit Program(const std::string &filename) {
     std::ifstream ifs(filename);
     std::string source(std::istreambuf_iterator<char>{ifs}, {});
     checkNvrtcCall(nvrtcCreateProgram(&program, source.c_str(),

--- a/include/nvrtc.hpp
+++ b/include/nvrtc.hpp
@@ -30,13 +30,24 @@ inline void checkNvrtcCall(nvrtcResult result) {
 
 class Program {
  public:
-  Program(const std::string &src, const std::string &name, int numHeaders = 0,
-          const char *headers[] = nullptr,
-          const char *includeNames[] =
-              nullptr)  // TODO: use std::vector<std::string>
-  {
+  Program(const std::string &src, const std::string &name,
+          const std::vector<std::string> &headers = std::vector<std::string>(),
+          const std::vector<std::string> &includeNames =
+              std::vector<std::string>()) {
+    std::vector<const char *> c_headers;
+    std::transform(headers.begin(), headers.end(),
+                   std::back_inserter(c_headers),
+                   [](const std::string &header) { return header.c_str(); });
+
+    std::vector<const char *> c_includeNames;
+    std::transform(
+        includeNames.begin(), includeNames.end(),
+        std::back_inserter(c_includeNames),
+        [](const std::string &includeName) { return includeName.c_str(); });
+
     checkNvrtcCall(nvrtcCreateProgram(&program, src.c_str(), name.c_str(),
-                                      numHeaders, headers, includeNames));
+                                      static_cast<int>(c_headers.size()),
+                                      c_headers.data(), c_includeNames.data()));
   }
 
   explicit Program(const std::string &filename) {
@@ -53,8 +64,8 @@ class Program {
     std::transform(options.begin(), options.end(),
                    std::back_inserter(c_options),
                    [](const std::string &option) { return option.c_str(); });
-    checkNvrtcCall(
-        nvrtcCompileProgram(program, c_options.size(), c_options.data()));
+    checkNvrtcCall(nvrtcCompileProgram(
+        program, static_cast<int>(c_options.size()), c_options.data()));
   }
 
   std::string getPTX() {
@@ -90,7 +101,7 @@ class Program {
   }
 
  private:
-  nvrtcProgram program;
+  nvrtcProgram program{};
 };
 }  // namespace nvrtc
 

--- a/include/nvrtc.hpp
+++ b/include/nvrtc.hpp
@@ -16,7 +16,7 @@ class Error : public std::exception {
  public:
   Error(nvrtcResult result) : _result(result) {}
 
-  virtual const char *what() const noexcept;
+  const char *what() const noexcept override;
 
   operator nvrtcResult() const { return _result; }
 
@@ -58,7 +58,7 @@ class Program {
   }
 
   std::string getPTX() {
-    size_t size;
+    size_t size{};
     std::string ptx;
 
     checkNvrtcCall(nvrtcGetPTXSize(program, &size));
@@ -69,7 +69,7 @@ class Program {
 
 #if CUDA_VERSION >= 11020
   std::vector<char> getCUBIN() {
-    size_t size;
+    size_t size{};
     std::vector<char> cubin;
 
     checkNvrtcCall(nvrtcGetCUBINSize(program, &size));
@@ -80,7 +80,7 @@ class Program {
 #endif
 
   std::string getLog() {
-    size_t size;
+    size_t size{};
     std::string log;
 
     checkNvrtcCall(nvrtcGetProgramLogSize(program, &size));

--- a/src/cu.cpp
+++ b/src/cu.cpp
@@ -15,14 +15,14 @@ const char *Error::what() const noexcept {
 Context Device::primaryCtxRetain() {
   CUcontext context{};
   checkCudaCall(cuDevicePrimaryCtxRetain(&context, _obj));
-  return Context(context, *this);
+  return {context, *this};
 }
 
 void Source::compile(const char *output_file_name,
                      const char *compiler_options) {
   std::stringstream command_line;
   command_line << "nvcc -cubin " << compiler_options << " -o "
-               << output_file_name << ' ' << input_file_name;
+               << output_file_name << ' ' << _input_file_name;
   //#pragma omp critical (clog)
   // std::clog << command_line.str() << std::endl;
 

--- a/src/cu.cpp
+++ b/src/cu.cpp
@@ -6,14 +6,14 @@
 namespace cu {
 
 const char *Error::what() const noexcept {
-  const char *str;
+  const char *str{};
   return cuGetErrorString(_result, &str) != CUDA_ERROR_INVALID_VALUE
              ? str
              : "unknown error";
 }
 
 Context Device::primaryCtxRetain() {
-  CUcontext context;
+  CUcontext context{};
   checkCudaCall(cuDevicePrimaryCtxRetain(&context, _obj));
   return Context(context, *this);
 }


### PR DESCRIPTION
**Description**

Address linter issues in cu and nvrtc libraries

**Related issues**:

Fixes part of #92

**Instructions to review the pull request**

- Check that things still work as expected
- Check that no linter issues are reported anymore

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```
-->

<!--
Review online.
-->
