### PR TITLE
Improve error message if file with cuda code does not exist

### DIFF
--- a/include/nvrtc.hpp
+++ b/include/nvrtc.hpp
@@ -42,7 +42,8 @@ class Program {
   Program(const std::string &filename) {
     std::ifstream ifs(filename);
     if (!ifs.is_open()) {
-      throw std::runtime_error("Error opening file: '" + filename + "'");
+      throw std::runtime_error("Error opening file '" + filename +
+                               "' in cudawrappers::nvrtc");
     }
     std::string source(std::istreambuf_iterator<char>{ifs}, {});
     checkNvrtcCall(nvrtcCreateProgram(&program, source.c_str(),

--- a/include/nvrtc.hpp
+++ b/include/nvrtc.hpp
@@ -42,8 +42,7 @@ class Program {
   Program(const std::string &filename) {
     std::ifstream ifs(filename);
     if (!ifs.is_open()) {
-      throw std::runtime_error(
-          std::string("Error opening file: '" + filename + "'"));
+      throw std::runtime_error("Error opening file: '" + filename + "'");
     }
     std::string source(std::istreambuf_iterator<char>{ifs}, {});
     checkNvrtcCall(nvrtcCreateProgram(&program, source.c_str(),

--- a/include/nvrtc.hpp
+++ b/include/nvrtc.hpp
@@ -41,6 +41,10 @@ class Program {
 
   Program(const std::string &filename) {
     std::ifstream ifs(filename);
+    if (!ifs.is_open()) {
+      throw std::runtime_error(
+          std::string("Error opening file: '" + filename + "'"));
+    }
     std::string source(std::istreambuf_iterator<char>{ifs}, {});
     checkNvrtcCall(nvrtcCreateProgram(&program, source.c_str(),
                                       filename.c_str(), 0, nullptr, nullptr));


### PR DESCRIPTION
This improves the error message if the file with cuda code cannot be opened when constructing an `nvrtc::Program`. Currently it is
```
cu::Error: named symbol not found
```
This pull request changes it to
```
terminate called after throwing an instance of 'std::runtime_error'
  what():  Error opening file: 'vector_add_kernel.cu'
```