### PR TITLE
Use CTest for testing and embed CUDA code in compiled module in example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,8 +12,8 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_EXTENSIONS False)
 set(CMAKE_BUILD_TYPE Release)
 option(BUILD_SHARED_LIBS "Create shared libraries" True)
-include(CTest)
 option(BUILD_TESTING "Built tests" False)
+include(CTest)
 
 # Enable Clang compiler warnings
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_EXTENSIONS False)
 set(CMAKE_BUILD_TYPE Release)
 option(BUILD_SHARED_LIBS "Create shared libraries" True)
+include(CTest)
+option(BUILD_TESTING "Built tests" False)
 
 # Enable Clang compiler warnings
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
@@ -97,8 +99,10 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake
 # Including linters rules
 include(cmake/linter-tools.cmake)
 
-# Tests
-add_subdirectory(tests)
+# Configure tests
+if(BUILD_TESTING)
+  add_subdirectory(tests)
+endif()
 
 # --- auto-ignore build directory
 if(NOT EXISTS ${PROJECT_BINARY_DIR}/.gitignore)

--- a/README.dev.md
+++ b/README.dev.md
@@ -66,10 +66,10 @@ Check that `nvcc` is working with `nvcc --version`.
 
 ## Building
 
-The following commands will compile and create a library `libcudawrappers.so`.
+The following commands will compile the libraries and tests:
 
 ```sh
-cmake -S . -B build
+cmake -S . -B build -DBUILD_TESTING=ON
 make --directory=build
 ```
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,10 +1,2 @@
 # vector_add
 add_subdirectory(vector_add)
-
-# This command will be executed from the test folder, which is where the .cu
-# file must be located
-add_custom_target(
-  test
-  COMMAND vector_add/vector_add
-  DEPENDS vector_add
-)

--- a/tests/vector_add/CMakeLists.txt
+++ b/tests/vector_add/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copies the kernel function to the tests folder
 file(COPY vector_add_kernel.cu DESTINATION ..)
-add_executable(vector_add EXCLUDE_FROM_ALL vector_add.cpp)
-target_link_libraries(
-  vector_add PRIVATE cudawrappers CUDA::cuda_driver CUDA::nvrtc
-)
+add_executable(vector_add vector_add.cpp)
+target_link_libraries(vector_add PRIVATE cudawrappers::cu cudawrappers::nvrtc)
+
+add_test(NAME vector_add COMMAND vector_add)

--- a/tests/vector_add/CMakeLists.txt
+++ b/tests/vector_add/CMakeLists.txt
@@ -1,6 +1,20 @@
-# Copies the kernel function to the tests folder
-file(COPY vector_add_kernel.cu DESTINATION ..)
+# Make it possible to #include cuda source code
+function(include_cuda_code target input_file)
+  # Save file containing cuda code as a C++ raw string literal
+  file(READ ${input_file} content)
+  set(delim "for_c++_include")
+  set(content "R\"${delim}(\n${content})${delim}\"")
+  set(output_file "${CMAKE_CURRENT_BINARY_DIR}/${input_file}")
+  file(WRITE ${output_file} "${content}")
+  # Add save path to the include directories
+  get_filename_component(output_subdir ${input_file} DIRECTORY)
+  target_include_directories(
+    ${target} PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/${output_subdir}"
+  )
+endfunction(include_cuda_code)
+
 add_executable(vector_add vector_add.cpp)
 target_link_libraries(vector_add PRIVATE cudawrappers::cu cudawrappers::nvrtc)
+include_cuda_code(vector_add kernels/vector_add_kernel.cu)
 
 add_test(NAME vector_add COMMAND vector_add)

--- a/tests/vector_add/kernels/vector_add_kernel.cu
+++ b/tests/vector_add/kernels/vector_add_kernel.cu
@@ -1,5 +1,3 @@
-
-
 extern "C" __global__ void vector_add(float *c, float *a, float *b, int n) {
   int i = blockIdx.x * blockDim.x + threadIdx.x;
   if (i < n) {

--- a/tests/vector_add/vector_add.cpp
+++ b/tests/vector_add/vector_add.cpp
@@ -33,7 +33,10 @@ void vector_add() {
 
   // compile kernel
   std::vector<std::string> options = {};
-  nvrtc::Program program("vector_add_kernel.cu");
+  const std::string vector_add_kernel =
+#include "vector_add_kernel.cu"
+      ;
+  nvrtc::Program program(vector_add_kernel, "vector_add_kernel.cu");
   try {
     program.compile(options);
   } catch (nvrtc::Error &error) {
@@ -59,10 +62,13 @@ void vector_add() {
 }
 
 int main(int argc, char *argv[]) {
+  int err{0};
   try {
     cu::init();
     vector_add();
   } catch (cu::Error &error) {
     std::cerr << "cu::Error: " << error.what() << std::endl;
+    err = 1;
   }
+  return err;
 }


### PR DESCRIPTION
**Description**

- Use the CTest framework to run the test instead of defining a custom command.
- Embed CUDA code and return correct exit code

**Instructions to review the pull request**

Compile and run the test (vector_add) using the instructions in README.dev.md

- Check that CHANGELOG.md has been updated if necessary

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```
-->

<!--
Review online.
-->
