### PR TITLE
Temporarily disable clang-tidy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,9 +6,6 @@ repos:
   - repo: https://github.com/pocc/pre-commit-hooks
     rev: v1.3.5
     hooks:
-      #- id: clang-tidy
-      #  types_or: ['c++', 'cuda']
-      #  args: ['-p=build']
       - id: cppcheck
         args:
           - '--project=build/compile_commands.json'
@@ -23,6 +20,5 @@ repos:
 
 ci:
   skip:
-    #- clang-tidy
     - cppcheck
     - cmake-lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,9 +6,9 @@ repos:
   - repo: https://github.com/pocc/pre-commit-hooks
     rev: v1.3.5
     hooks:
-      - id: clang-tidy
-        types_or: ['c++', 'cuda']
-        args: ['-p=build']
+      #- id: clang-tidy
+      #  types_or: ['c++', 'cuda']
+      #  args: ['-p=build']
       - id: cppcheck
         args:
           - '--project=build/compile_commands.json'
@@ -23,6 +23,6 @@ repos:
 
 ci:
   skip:
-    - clang-tidy
+    #- clang-tidy
     - cppcheck
     - cmake-lint


### PR DESCRIPTION
**Description**

Temporarily disable clang-tidy, until we fix the spurious errors it gives about system headers.

**Related issues**:
#194 
