### PR TITLE
Suggestion: improve CI runtime

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           cuda: ${{ env.cuda-version }}
           method: "network"
-          sub-packages: '["nvcc"]'
+          sub-packages: '["nvcc", "nvrtc", "nvtx", "cufft"]'
           linux-local-args: '["--toolkit"]'
 
       - name: Generate compilation database

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,9 +12,11 @@ jobs:
         # set tools versions to latest supported by the CI runner,
         # ubuntu 22.04 at the time of writing
         # clang defaults to v14.0.0
-        gcc-version: 12  # = 12.1.0
+        gcc-version: "12"  # = 12.1.0
         # cuda version to install with separate action
         cuda-version: "12.2.0"
+        # version for cmake-lint and cmake-format
+        cmakelang-version: "0.6.13"
     steps:
 
       - name: Show git version
@@ -61,7 +63,7 @@ jobs:
 
       - name: Install pre-commit and related tools
         run: |
-          pip install pre-commit cmake-lint cmake-format
+          pip install pre-commit cmakelang==${{ env.cmakelang-version}}
           sudo apt install cppcheck -y
 
       - name: Show tool versions

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -59,9 +59,9 @@ jobs:
           non-cuda-sub-packages: '["libcufft-dev", "libcublas-dev"]'
           linux-local-args: '["--toolkit"]'
 
-      - name: Install pre-commit and cppcheck
+      - name: Install pre-commit and related tools
         run: |
-          pip install pre-commit
+          pip install pre-commit cmake-lint cmake-format
           sudo apt install cppcheck -y
 
       - name: Show tool versions

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,5 +1,4 @@
 name: pre-commit
-# conda cache setup based on https://github.com/epassaro/cache-conda-envs
 
 on:
   push:
@@ -43,23 +42,6 @@ jobs:
         run: |
           git checkout ${{ env.precommit_from_ref }}
           git checkout ${{ env.precommit_to_ref }}
-
-      - name: Setup environment with Mamba
-        uses: conda-incubator/setup-miniconda@v2
-        with:
-          mamba-version: "*"
-          channels: conda-forge
-          activate-environment: recruit
-
-      - uses: actions/cache@v2
-        with:
-          path: /usr/share/miniconda/envs/recruit
-          key: conda-${{ hashFiles('environment.yml') }}
-        id: cache
-
-      - name: Update mamba environment if cache is outdated
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: mamba env update -n recruit -f environment.yml
 
       - name: Generate compilation database
         shell: bash -el {0}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -59,9 +59,10 @@ jobs:
           non-cuda-sub-packages: '["libcufft-dev", "libcublas-dev"]'
           linux-local-args: '["--toolkit"]'
 
-      - name: Install pre-commit
+      - name: Install pre-commit and cppcheck
         run: |
           pip install pre-commit
+          sudo apt install cppcheck -y
 
       - name: Generate compilation database
         shell: bash -el {0}
@@ -72,5 +73,6 @@ jobs:
         shell: bash -el {0}
         run: |
           git diff --name-only ${{ env.precommit_from_ref }}...${{ env.precommit_to_ref }}
+          clang-format --version
           pre-commit run -a
           #pre-commit run --from-ref ${{ env.precommit_from_ref }} --to-ref ${{ env.precommit_to_ref }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -72,4 +72,5 @@ jobs:
         shell: bash -el {0}
         run: |
           git diff --name-only ${{ env.precommit_from_ref }}...${{ env.precommit_to_ref }}
-          pre-commit run --from-ref ${{ env.precommit_from_ref }} --to-ref ${{ env.precommit_to_ref }}
+          pre-commit run -a
+          #pre-commit run --from-ref ${{ env.precommit_from_ref }} --to-ref ${{ env.precommit_to_ref }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,10 +9,10 @@ jobs:
     name: run
     runs-on: ubuntu-latest
     env:
-        # gcc and clang are the latest supported by the CI runner,
+        # set tools versions to latest supported by the CI runner,
         # ubuntu 22.04 at the time of writing
+        # clang defaults to v14.0.0
         gcc-version: 12  # = 12.1.0
-        clang-version: 14  # = 14.0.0
         # cuda version to install with separate action
         cuda-version: "12.2.0"
     steps:
@@ -64,6 +64,16 @@ jobs:
           pip install pre-commit
           sudo apt install cppcheck -y
 
+      - name: Show tool versions
+        run: |
+           nvcc --version
+           g++-${{ env.gcc-version}} --version
+           clang-format --version
+           clang-tidy --version
+           cppcheck --version
+           cmake-lint --version
+           cmake-format --version
+
       - name: Generate compilation database
         shell: bash -el {0}
         run: |
@@ -73,6 +83,5 @@ jobs:
         shell: bash -el {0}
         run: |
           git diff --name-only ${{ env.precommit_from_ref }}...${{ env.precommit_to_ref }}
-          clang-format --version
           pre-commit run -a
           #pre-commit run --from-ref ${{ env.precommit_from_ref }} --to-ref ${{ env.precommit_to_ref }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -68,13 +68,13 @@ jobs:
 
       - name: Show tool versions
         run: |
-           nvcc --version
-           g++-${{ env.gcc-version}} --version
-           clang-format --version
-           clang-tidy --version
-           cppcheck --version
-           cmake-lint --version
-           cmake-format --version
+           echo "nvcc: $(nvcc --version)"
+           echo "g++: $(g++-${{ env.gcc-version}} --version)"
+           echo "clang-format: $(clang-format --version)"
+           echo "clang-tidy: $(clang-tidy --version)"
+           echo "cppcheck: $(cppcheck --version)"
+           echo "cmake-lint: $(cmake-lint --version)"
+           echo "cmake-format: $(cmake-format --version)"
 
       - name: Generate compilation database
         shell: bash -el {0}
@@ -85,5 +85,4 @@ jobs:
         shell: bash -el {0}
         run: |
           git diff --name-only ${{ env.precommit_from_ref }}...${{ env.precommit_to_ref }}
-          pre-commit run -a
-          #pre-commit run --from-ref ${{ env.precommit_from_ref }} --to-ref ${{ env.precommit_to_ref }}
+          pre-commit run --from-ref ${{ env.precommit_from_ref }} --to-ref ${{ env.precommit_to_ref }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,6 +8,13 @@ jobs:
   linting:
     name: run
     runs-on: ubuntu-latest
+    env:
+        # gcc and clang are the latest supported by the CI runner,
+        # ubuntu 22.04 at the time of writing
+        gcc-version: 12  # = 12.1.0
+        clang-version: 14  # = 14.0.0
+        # cuda version to install with separate action
+        cuda-version: "12.1.0"
     steps:
 
       - name: Show git version
@@ -43,10 +50,15 @@ jobs:
           git checkout ${{ env.precommit_from_ref }}
           git checkout ${{ env.precommit_to_ref }}
 
+      - name: Install cuda
+        uses: Jimver/cuda-toolkit@v0.2
+        with:
+          cuda: ${{ env.cuda-version }}
+
       - name: Generate compilation database
         shell: bash -el {0}
         run: |
-          cmake -DCMAKE_CXX_COMPILER=clang++ -DCUDAWRAPPERS_BUILD_TESTING=True -DCUDAWRAPPERS_BUILD_EXAMPLES=True -S . -B build
+          cmake -DCMAKE_CXX_COMPILER=g++-${{ env.gcc-version }} -DCUDAWRAPPERS_BUILD_TESTING=True -DCUDAWRAPPERS_BUILD_EXAMPLES=True -S . -B build
 
       - name: Run pre-commit on all files changed in this branch using project standard configuration
         shell: bash -el {0}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -55,7 +55,8 @@ jobs:
         with:
           cuda: ${{ env.cuda-version }}
           method: "network"
-          sub-packages: '["nvcc", "nvrtc", "nvtx", "cufft"]'
+          sub-packages: '["nvcc", "nvrtc", "nvtx"]'
+          non-cuda-sub-packages: '["libcufft"]'
           linux-local-args: '["--toolkit"]'
 
       - name: Generate compilation database

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -59,6 +59,10 @@ jobs:
           non-cuda-sub-packages: '["libcufft-dev", "libcublas-dev"]'
           linux-local-args: '["--toolkit"]'
 
+      - name: Install pre-commit
+        run: |
+          pip install pre-commit
+
       - name: Generate compilation database
         shell: bash -el {0}
         run: |

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -55,8 +55,8 @@ jobs:
         with:
           cuda: ${{ env.cuda-version }}
           method: "network"
-          sub-packages: '["nvcc", "nvrtc", "nvtx"]'
-          non-cuda-sub-packages: '["libcufft"]'
+          sub-packages: '["nvcc", "nvrtc-dev", "nvtx"]'
+          non-cuda-sub-packages: '["libcufft-dev"]'
           linux-local-args: '["--toolkit"]'
 
       - name: Generate compilation database

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,7 +14,7 @@ jobs:
         gcc-version: 12  # = 12.1.0
         clang-version: 14  # = 14.0.0
         # cuda version to install with separate action
-        cuda-version: "12.1.0"
+        cuda-version: "12.2.0"
     steps:
 
       - name: Show git version
@@ -54,6 +54,9 @@ jobs:
         uses: Jimver/cuda-toolkit@v0.2.11
         with:
           cuda: ${{ env.cuda-version }}
+          method: "network"
+          sub-packages: ["nvcc"]
+          linux-localargs: ["--toolkit"]
 
       - name: Generate compilation database
         shell: bash -el {0}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -55,8 +55,8 @@ jobs:
         with:
           cuda: ${{ env.cuda-version }}
           method: "network"
-          sub-packages: ["nvcc"]
-          linux-localargs: ["--toolkit"]
+          sub-packages: '["nvcc"]'
+          linux-local-args: '["--toolkit"]'
 
       - name: Generate compilation database
         shell: bash -el {0}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -51,7 +51,7 @@ jobs:
           git checkout ${{ env.precommit_to_ref }}
 
       - name: Install cuda
-        uses: Jimver/cuda-toolkit@v0.2
+        uses: Jimver/cuda-toolkit@v0.2.11
         with:
           cuda: ${{ env.cuda-version }}
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -56,7 +56,7 @@ jobs:
           cuda: ${{ env.cuda-version }}
           method: "network"
           sub-packages: '["nvcc", "nvrtc-dev", "nvtx"]'
-          non-cuda-sub-packages: '["libcufft-dev"]'
+          non-cuda-sub-packages: '["libcufft-dev", "libcublas-dev"]'
           linux-local-args: '["--toolkit"]'
 
       - name: Generate compilation database

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -58,7 +58,7 @@ jobs:
           cuda: ${{ env.cuda-version }}
           method: "network"
           sub-packages: '["nvcc", "nvrtc-dev", "nvtx"]'
-          non-cuda-sub-packages: '["libcufft-dev", "libcublas-dev"]'
+          non-cuda-sub-packages: '["libcufft-dev"]'
           linux-local-args: '["--toolkit"]'
 
       - name: Install pre-commit and related tools

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,7 @@ repos:
           - '--suppress=*:build/*'
           - '--suppress=unusedFunction:*/*'
           - '--suppress=unreadVariable:tests/*'
+          - '--suppress=missingIncludeSystem'
   - repo: https://github.com/cheshirekow/cmake-format-precommit
     rev: v0.6.13
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,7 @@ repos:
           - '--suppress=unusedFunction:*/*'
           - '--suppress=unreadVariable:tests/*'
           - '--suppress=missingIncludeSystem'
+          - '--suppress=unmatchedSuppression'
   - repo: https://github.com/cheshirekow/cmake-format-precommit
     rev: v0.6.13
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v16.0.6
+    rev: v14.0.0
     hooks:
       - id: clang-format
   - repo: https://github.com/pocc/pre-commit-hooks

--- a/environment.yml
+++ b/environment.yml
@@ -3,11 +3,11 @@ channels:
   - conda-forge
 dependencies:
   - c-compiler
-  - clang==16.0.6
-  - clang-tools==16.0.6
+  - clang==14.0.0
+  - clang-tools==14.0.0
   - cmake>=3.17
   - cppcheck==2.10.3
-  - cudatoolkit-dev>=10.0
+  - cudatoolkit-dev==12.2.0
   - cxx-compiler
   - doxygen
   - gcovr
@@ -19,6 +19,6 @@ dependencies:
   - pip:
       - pre-commit
       - bump2version==1.0.1
-      - clang-format==16.0.6
+      - clang-format==14.0.0
       - cmakelang==0.6.13
       - flawfinder==2.0.19

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - clang==14.0.0
   - clang-tools==14.0.0
   - cmake>=3.17
-  - cppcheck==2.10.3
+  - cppcheck==2.7.5
   - cudatoolkit-dev==12.2.0
   - cxx-compiler
   - doxygen


### PR DESCRIPTION
**Description**

In an attempt to fix #189 I made an alternative pre-commit CI workflow that doesn't use conda. The runtime improved from ~7 minutes to <2 minutes.

This PR is one way of improving the CI runtime. Without conda, we depend on the tools available in the Github runner and apt/pip to install the missing ones. Most tools we need are already provided by the runner. I'm using apt/pip to install the missing linter/formatter tools, and a specific github action to install cuda (only the required parts of cuda, not everything as that takes a very long time).

The downside of this approach vs conda is that we are less flexible in the versions of some packages. The Github runners typically provide the latest 3 major versions of compilers etc, but for e.g. cppcheck we depend on apt and whatever version is available there. This is not necessarily a problem, but good to be aware of. The CI now prints the versions of all used tools as well, so one can more easily check if the local versions match. I've updated the versions in `environment.yml` to match the CI.

The current approach does make it easy to test with e.g. several CUDA versions using the Github actions matrix feature, but this is not implemented yet.

**Related issues**:
#189 describes a problem with the conda cache. This is fixed by removing conda completely. The conda environment build step typically took about 5 minutes. Now the major factor in the CI is installing cuda, which takes ~1 minute. `cmake` warns about not finding cublas, but everything else passes so I don't think we need it. Adding it increases build times by >50% so I've left it out for now.

As part of testing I forced the CI to run everything with `pre-commit run -a` instead of the current command, and everything passed.

**Instructions to review the pull request**
- Verify that the CI passes
- Verify that the versions listed in the CI output and in environment.yml are the same

