### PR TITLE
!191 Update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,14 +13,20 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 ## [0.4.0]
-
 ### Added
 
+- CTest for testing
+- nvtx library
+- bump2version
+
 ### Changed
+
+- Miscellaneous improvements to CMake and CI
 
 ### Removed
 
 - `Source` class. Use `nvrtc::Program` instead.
+- Commented out code that was not used (anymore)
 
 ## [0.3.0] - 2022-03-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
+- cufft wrappers for 1D and 2D complex-to-complex FFTs
 
 ### Changed
 


### PR DESCRIPTION
**Description**

The `CHANGELOG.md` was not updated for release 0.4.0. This is now corrected. Also, the cufft wrappers are added (to be included in release 0.5.0) and added to the changelog as well.

**Related issues**:

- https://github.com/nlesc-recruit/cudawrappers/issues/191

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```
-->

<!--
Review online.
-->
