### PR TITLE
!133 Update read the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,7 @@ This section aims to provide an overview of projects that use this repo's librar
 
 This section provides an overview of similar tools in this space, and how they are different.
 
-### cuda-api-wrappers
-
-url: https://github.com/eyalroz/cuda-api-wrappers
+### [cuda-api-wrappers](https://github.com/eyalroz/cuda-api-wrappers)
 
 - Aims to provide wrappers for the CUDA runtime API
 - Development has slowed a bit recently
@@ -89,15 +87,11 @@ url: https://github.com/eyalroz/cuda-api-wrappers
 
 The project is planning to support more of the Driver API (for fine-grained control of CUDA devices) and NVRTC API (for runtime compilation of kernels); there is a release candidate ([`v0.5.0-rc1`](https://github.com/eyalroz/cuda-api-wrappers/tree/v0.5.0-rc1)). It doesn't provide support for cuFFT and cuBLAS though.
 
-### cuda-wrapper
-
-url: https://github.com/halmd-org/cuda-wrapper
+### [cuda-wrapper](https://github.com/halmd-org/cuda-wrapper)
 
 - Aims to provide a C++ wrapper for the CUDA Driver and Runtime APIs
 
-### CudaPlusPlus
-
-url: https://github.com/apardyl/cudaplusplus
+### [CudaPlusPlus](https://github.com/apardyl/cudaplusplus)
 
 - Aims to provide a C++ wrapper for the CUDA Driver API
 - Project appears inactive

--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ The project is planning to support more of the Driver API (for fine-grained cont
 
 ## Contributing
 
-See [CONTRIBUTING](CONTRIBUTING.md) for a guide on how to contribute.
+See [CONTRIBUTING.md](https://github.com/nlesc-recruit/cudawrappers/blob/main/CONTRIBUTING.md) for a guide on how to contribute.
 
 ## Developer documentation
 
-See [README.dev.md](README.dev.md) for documentation on setting up your development environment.
+See [README.dev.md](https://github.com/nlesc-recruit/cudawrappers/blob/main/README.dev.md) for documentation on setting up your development environment.


### PR DESCRIPTION
**Description**

On [readthedocs](https://cudawrappers.readthedocs.io/en/latest/), the links to `CONTRIBUTING` and `CHANGELOG.md` are not clickable. These have been changed to be links to this repository. This is a workaround, since readthedocs has the option to view different versions of the documentation which now all link to files on the main branch.
As an alternative, we could point to these files at a specific tag, but this comes with the downside of always having to update the links upon a new release.

Additionally, the names of the alternatives to cudawrappers are now clickable.

**Related issues**:

- https://github.com/nlesc-recruit/cudawrappers/issues/133

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```
-->

<!--
Review online.
-->
