### PR TITLE
!167 Remove deprecated Context::getDevice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 - `Source` class. Use `nvrtc::Program` instead.
+- `getDevice` function of `Context`.
 - Commented out code that was not used (anymore)
 
 ## [0.3.0] - 2022-03-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 ### Removed
-- `getDevice` function of `Context`
+- `getDevice` function of `Context`, use `Device` constructor instead
 
 ## [0.4.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 ### Removed
+- `getDevice` function of `Context`
 
 ## [0.4.0]
 ### Added
@@ -26,7 +27,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 - `Source` class. Use `nvrtc::Program` instead.
-- `getDevice` function of `Context`.
 - Commented out code that was not used (anymore)
 
 ## [0.3.0] - 2022-03-08

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -188,12 +188,6 @@ class Context : public Wrapper<CUcontext> {
     checkCudaCall(cuCtxSetSharedMemConfig(config));
   }
 
-  static Device getDevice() {
-    CUdevice device{};
-    checkCudaCall(cuCtxGetDevice(&device));
-    return Device(device);  // FIXME: ~Device()
-  }
-
   static size_t getLimit(CUlimit limit) {
     size_t value{};
     checkCudaCall(cuCtxGetLimit(&value, limit));


### PR DESCRIPTION
**Description**

There was as `FIXME` at the `Context::getDevice` function, related to the destructor.  It appears that the function isn't needed at all. One should instantiate `cu::Device` instances by calling the constructor of `Device` and pass the `Context` as an argument. Therefore, `Context::getDevice` is deprecated and now removed.

**Related issues**:

- https://github.com/nlesc-recruit/cudawrappers/issues/187

**Instructions to review the pull request**

- Check that CHANGELOG.md has been updated if necessary

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```
-->

<!--
Review online.
-->
