### PR TITLE
Update howfairis-github-action to 0.2.1

### DIFF
--- a/.github/workflows/fair-software.yml
+++ b/.github/workflows/fair-software.yml
@@ -13,9 +13,9 @@ jobs:
     name: "fair-software"
     runs-on: ubuntu-latest
     steps:
-      - uses: fair-software/howfairis-github-action@0.2.0
+      - uses: fair-software/howfairis-github-action@0.2.1
         name: Measure compliance with fair-software.eu recommendations
         env:
-          PYCHARM_HOSTED: "Trick colorama into displaying colored output" 
+          PYCHARM_HOSTED: "Trick colorama into displaying colored output"
         with:
           MY_REPO_URL: "https://github.com/${{ github.repository }}"


### PR DESCRIPTION
**Description**

We noticed that the `howfairis` GitHub action fails on building the Docker container. This problem unrelated to any code in this (cudawrappers) repository. The problem can also be reproduced locally be cloning https://github.com/fair-software/howfairis-github-action at 0.2.0 an building the container. The latest version ([0.2.1](https://github.com/fair-software/howfairis-github-action/releases/tag/0.2.1)) build correctly and upgrading to this version for cudawrappers should also fix the CI.

**Related issues**:

- N.A.

**Instructions to review the pull request**

- Check that CHANGELOG.md has been updated if necessary

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```
-->

<!--
Review online.
-->
