### PR TITLE
Update CMake for unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ find_package(CUDAToolkit ${CUDA_MIN_VERSION} REQUIRED)
 # Configure tests
 if(CUDAWRAPPERS_BUILD_TESTING)
   include(CTest)
+  enable_testing()
 
   # Set up coverage collection
   add_compile_options(--coverage -g -O0)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,25 +12,23 @@ FetchContent_MakeAvailable(Catch2)
 list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/contrib)
 include(Catch)
 
-add_executable(test_cu test_cu.cpp)
-target_link_libraries(test_cu PUBLIC Catch2::Catch2 cudawrappers::cu)
-catch_discover_tests(test_cu)
-
-add_executable(test_nvrtc test_nvrtc.cpp)
-target_link_libraries(
-  test_nvrtc PUBLIC Catch2::Catch2 cudawrappers::cu cudawrappers::nvrtc
-)
-catch_discover_tests(test_nvrtc)
-
-add_executable(test_cufft test_cufft.cpp)
-target_link_libraries(
-  test_cufft PUBLIC Catch2::Catch2 cudawrappers::cu cudawrappers::cufft
-)
-catch_discover_tests(test_cufft)
-
 set(COMPONENTS cu nvrtc cufft)
+
 foreach(component ${COMPONENTS})
+  add_executable(test_${component} test_${component}.cpp)
   target_include_directories(
     test_${component} PRIVATE "${CMAKE_SOURCE_DIR}/include"
   )
+  catch_discover_tests(test_${component})
 endforeach()
+
+set(LINK_LIBRARIES Catch2::Catch2 cudawrappers::cu)
+
+target_link_libraries(test_cu PUBLIC ${LINK_LIBRARIES})
+catch_discover_tests(test_cu)
+
+target_link_libraries(test_nvrtc PUBLIC ${LINK_LIBRARIES} cudawrappers::nvrtc)
+catch_discover_tests(test_nvrtc)
+
+target_link_libraries(test_cufft PUBLIC ${LINK_LIBRARIES} cudawrappers::cufft)
+catch_discover_tests(test_cufft)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,23 +12,25 @@ FetchContent_MakeAvailable(Catch2)
 list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/contrib)
 include(Catch)
 
-# Compile Catch2
-add_library(tests)
-target_sources(tests PRIVATE main.cpp)
-target_link_libraries(tests PUBLIC Catch2::Catch2)
-set(LINK_cu cudawrappers::cu)
-set(LINK_cufft cudawrappers::cu cudawrappers::cufft)
-set(LINK_nvrtc cudawrappers::nvrtc)
+add_executable(test_cu test_cu.cpp)
+target_link_libraries(test_cu PUBLIC Catch2::Catch2 cudawrappers::cu)
+catch_discover_tests(test_cu)
 
-# Add library tests
+add_executable(test_nvrtc test_nvrtc.cpp)
+target_link_libraries(
+  test_nvrtc PUBLIC Catch2::Catch2 cudawrappers::cu cudawrappers::nvrtc
+)
+catch_discover_tests(test_nvrtc)
+
+add_executable(test_cufft test_cufft.cpp)
+target_link_libraries(
+  test_cufft PUBLIC Catch2::Catch2 cudawrappers::cu cudawrappers::cufft
+)
+catch_discover_tests(test_cufft)
+
 set(COMPONENTS cu nvrtc cufft)
 foreach(component ${COMPONENTS})
-  add_executable(test_${component} test_${component}.cpp)
-  target_link_libraries(test_${component} PUBLIC ${LINK_${component}} tests)
-  catch_discover_tests(test_${component})
-  foreach(test_name ${test_${component}_TESTS})
-    add_test(NAME test_${component}::${test_name} COMMAND test_${component}
-                                                          ${test_name}
-    )
-  endforeach()
+  target_include_directories(
+    test_${component} PRIVATE "${CMAKE_SOURCE_DIR}/include"
+  )
 endforeach()

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,2 +1,0 @@
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>

--- a/tests/test_cu.cpp
+++ b/tests/test_cu.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <string>
 
+#define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
 #include <cuda.h>
 #include <cudawrappers/cu.hpp>

--- a/tests/test_cufft.cpp
+++ b/tests/test_cufft.cpp
@@ -1,6 +1,7 @@
 #include <fstream>
 #include <iostream>
 
+#define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
 #include <cudawrappers/cufft.hpp>
 

--- a/tests/test_nvrtc.cpp
+++ b/tests/test_nvrtc.cpp
@@ -1,6 +1,7 @@
 #include <string>
 #include <vector>
 
+#define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
 #include <cudawrappers/nvrtc.hpp>
 


### PR DESCRIPTION
**Description**

The tests executables `test_cu`, `test_nvrtc` and `test_cufft` were build, but running `ctest` or `make test` didn't detect them. This is now solved by changing the `CMakeLists`.

**Related issues**:

- https://github.com/nlesc-recruit/cudawrappers/issues/148

**Instructions to review the pull request**

- Check that CHANGELOG.md has been updated if necessary

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```
-->

<!--
Review online.
-->
