### PR TITLE
Fix __half division by float

### DIFF
--- a/tests/test_cufft.cpp
+++ b/tests/test_cufft.cpp
@@ -28,8 +28,8 @@ void generateSignal(T *in, size_t height, size_t width, size_t patchSize,
 template <typename T>
 void scaleSignal(T *in, T *out, size_t n, float scale) {
   for (size_t i = 0; i < n; i++) {
-    out[i].x = in[i].x / scale;
-    out[i].y = in[i].y / scale;
+    out[i].x = static_cast<float>(in[i].x) / scale;
+    out[i].y = static_cast<float>(in[i].y) / scale;
   }
 }
 


### PR DESCRIPTION
In cuda version 12.2 the division by float is somewhat not supported out of the box so a static cast is required.

If you test with different version of cuda (as for instance 12.1 and 12.2) you can reproduce this issue. 
The version of the compiler does not matter.

