### PR TITLE
Add managed memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - cufft wrappers for 1D and 2D complex-to-complex FFTs
 - cu::HostMemory constuctor for pre-allocated memory
+- cu::DeviceMemory constructor for managed memory
+- cu::Stream::cuMemPrefetchAsync for pre-fetching of managed memory
 
 ### Changed
 - The vector_add example has now become a test

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -441,6 +441,10 @@ class Stream : public Wrapper<CUstream> {
     checkCudaCall(cuMemcpyAsync(dstPtr, srcPtr, size, _obj));
   }
 
+  void memPrefetchAsync(CUdeviceptr devPtr, CUdevice dstDevice, size_t size) {
+    cuMemPrefetchAsync(devPtr, size, dstDevice, _obj);
+  }
+
   void launchKernel(Function &function, unsigned gridX, unsigned gridY,
                     unsigned gridZ, unsigned blockX, unsigned blockY,
                     unsigned blockZ, unsigned sharedMemBytes,

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -247,21 +247,16 @@ class DeviceMemory : public Wrapper<CUdeviceptr> {
                         unsigned int flags = 0) {
     if (type == CU_MEMORYTYPE_DEVICE and !flags) {
       checkCudaCall(cuMemAlloc(&_obj, size));
-      manager = std::shared_ptr<CUdeviceptr>(new CUdeviceptr(_obj),
-                                             [](CUdeviceptr *ptr) {
-                                               cuMemFree(*ptr);
-                                               delete ptr;
-                                             });
     } else if (type == CU_MEMORYTYPE_UNIFIED) {
       checkCudaCall(cuMemAllocManaged(&_obj, size, flags));
-      manager = std::shared_ptr<CUdeviceptr>(new CUdeviceptr(_obj),
-                                             [](CUdeviceptr *ptr) {
-                                               cuMemFree(*ptr);
-                                               delete ptr;
-                                             });
     } else {
       throw Error(CUDA_ERROR_INVALID_VALUE);
     }
+    manager = std::shared_ptr<CUdeviceptr>(new CUdeviceptr(_obj),
+                                           [](CUdeviceptr *ptr) {
+                                             cuMemFree(*ptr);
+                                             delete ptr;
+                                           });
   }
 
   explicit DeviceMemory(CUdeviceptr ptr) : Wrapper(ptr) {}

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -442,7 +442,7 @@ class Stream : public Wrapper<CUstream> {
   }
 
   void memPrefetchAsync(CUdeviceptr devPtr, CUdevice dstDevice, size_t size) {
-    cuMemPrefetchAsync(devPtr, size, dstDevice, _obj);
+    checkCudaCall(cuMemPrefetchAsync(devPtr, size, dstDevice, _obj));
   }
 
   void launchKernel(Function &function, unsigned gridX, unsigned gridY,

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -436,7 +436,8 @@ class Stream : public Wrapper<CUstream> {
     checkCudaCall(cuMemcpyAsync(dstPtr, srcPtr, size, _obj));
   }
 
-  void memPrefetchAsync(CUdeviceptr devPtr, size_t size, CUdevice dstDevice) {
+  void memPrefetchAsync(CUdeviceptr devPtr, size_t size,
+                        CUdevice dstDevice = CU_DEVICE_CPU) {
     checkCudaCall(cuMemPrefetchAsync(devPtr, size, dstDevice, _obj));
   }
 

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -436,7 +436,7 @@ class Stream : public Wrapper<CUstream> {
     checkCudaCall(cuMemcpyAsync(dstPtr, srcPtr, size, _obj));
   }
 
-  void memPrefetchAsync(CUdeviceptr devPtr, CUdevice dstDevice, size_t size) {
+  void memPrefetchAsync(CUdeviceptr devPtr, size_t size, CUdevice dstDevice) {
     checkCudaCall(cuMemPrefetchAsync(devPtr, size, dstDevice, _obj));
   }
 

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -277,7 +277,15 @@ class DeviceMemory : public Wrapper<CUdeviceptr> {
 
   template <typename T>
   operator T *() {
-    return reinterpret_cast<T *>(_obj);
+    bool data;
+    checkCudaCall(
+        cuPointerGetAttribute(&data, CU_POINTER_ATTRIBUTE_IS_MANAGED, _obj));
+    if (data) {
+      return reinterpret_cast<T *>(_obj);
+    } else {
+      throw std::runtime_error(
+          "Cannot return memory of type CU_MEMORYTYPE_DEVICE as pointer.");
+    }
   }
 };
 

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -274,6 +274,11 @@ class DeviceMemory : public Wrapper<CUdeviceptr> {
   {
     return &_obj;
   }
+
+  template <typename T>
+  operator T *() {
+    return reinterpret_cast<T *>(_obj);
+  }
 };
 
 class Array : public Wrapper<CUarray> {

--- a/tests/test_cu.cpp
+++ b/tests/test_cu.cpp
@@ -143,4 +143,17 @@ TEST_CASE("Test zeroing cu::DeviceMemory", "[zero]") {
 
     CHECK(data_in == data_out);
   }
+
+  SECTION("Test cu::DeviceMemory with CU_MEMORYTYPE_DEVICE as host pointer") {
+    cu::DeviceMemory mem(sizeof(float), CU_MEMORYTYPE_DEVICE, 0);
+    float* ptr;
+    CHECK_THROWS(ptr = mem);
+  }
+
+  SECTION("Test cu::DeviceMemory with CU_MEMORYTYPE_UNIFIED as host pointer") {
+    cu::DeviceMemory mem(sizeof(float), CU_MEMORYTYPE_UNIFIED,
+                         CU_MEM_ATTACH_GLOBAL);
+    float* ptr = mem;
+    CHECK_NOTHROW(ptr[0] = 42.f);
+  }
 }

--- a/tests/test_vector_add.cpp
+++ b/tests/test_vector_add.cpp
@@ -15,6 +15,15 @@ void check_arrays_equal(const float *a, const float *b, size_t n) {
   }
 }
 
+void initialize_arrays(float *a, float *b, float *c, float *r, int N) {
+  for (int i = 0; i < N; i++) {
+    a[i] = 1.0 + i;
+    b[i] = 2.0 - (N - i);
+    c[i] = 0.0;
+    r[i] = a[i] + b[i];
+  }
+}
+
 TEST_CASE("Vector add") {
   const std::string kernel = R"(
     extern "C" __global__ void vector_add(float *c, float *a, float *b, int n) {
@@ -32,28 +41,7 @@ TEST_CASE("Vector add") {
   cu::Device device(0);
   cu::Context context(CU_CTX_SCHED_BLOCKING_SYNC, device);
 
-  cu::HostMemory h_a(bytesize);
-  cu::HostMemory h_b(bytesize);
-  cu::HostMemory h_c(bytesize);
-  std::vector<float> reference_c(N);
-
-  float *a = static_cast<float *>(h_a);
-  float *b = static_cast<float *>(h_b);
-  float *c = static_cast<float *>(h_c);
-  for (int i = 0; i < N; i++) {
-    a[i] = 1.0 + i;
-    b[i] = 2.0 - (N - i);
-    c[i] = 0.0;
-    reference_c[i] = a[i] + b[i];
-  }
-
-  cu::DeviceMemory d_a(bytesize);
-  cu::DeviceMemory d_b(bytesize);
-  cu::DeviceMemory d_c(bytesize);
-
   cu::Stream stream;
-  stream.memcpyHtoDAsync(d_a, a, bytesize);
-  stream.memcpyHtoDAsync(d_b, b, bytesize);
 
   std::vector<std::string> options = {};
   nvrtc::Program program(kernel, "vector_add_kernel.cu");
@@ -68,11 +56,26 @@ TEST_CASE("Vector add") {
   cu::Function function(module, "vector_add");
 
   SECTION("Run kernel") {
+    cu::HostMemory h_a(bytesize);
+    cu::HostMemory h_b(bytesize);
+    cu::HostMemory h_c(bytesize);
+    std::vector<float> reference_c(N);
+
+    initialize_arrays(static_cast<float *>(h_a), static_cast<float *>(h_b),
+                      static_cast<float *>(h_c), reference_c.data(), N);
+
+    cu::DeviceMemory d_a(bytesize);
+    cu::DeviceMemory d_b(bytesize);
+    cu::DeviceMemory d_c(bytesize);
+
+    stream.memcpyHtoDAsync(d_a, h_a, bytesize);
+    stream.memcpyHtoDAsync(d_b, h_b, bytesize);
     std::vector<const void *> parameters = {d_c.parameter(), d_a.parameter(),
                                             d_b.parameter(), &N};
     stream.launchKernel(function, 1, 1, 1, N, 1, 1, 0, parameters);
-    stream.memcpyDtoHAsync(c, d_c, bytesize);
+    stream.memcpyDtoHAsync(h_c, d_c, bytesize);
     stream.synchronize();
-    check_arrays_equal(c, reference_c.data(), N);
+
+    check_arrays_equal(h_c, reference_c.data(), N);
   }
 }

--- a/tests/test_vector_add.cpp
+++ b/tests/test_vector_add.cpp
@@ -126,4 +126,17 @@ TEST_CASE("Vector add") {
       check_arrays_equal(h_c, reference_c.data(), N);
     }
   }
+
+  SECTION("Pass invalid CUmemorytype to cu::DeviceMemory constructor") {
+    CHECK_THROWS(cu::DeviceMemory(bytesize, CU_MEMORYTYPE_ARRAY));
+    CHECK_THROWS(cu::DeviceMemory(bytesize, CU_MEMORYTYPE_HOST));
+  }
+
+  SECTION("Pass flags with CU_MEMORYTYPE_DEVICE") {
+    CHECK_NOTHROW(cu::DeviceMemory(bytesize, CU_MEMORYTYPE_DEVICE, 0));
+    CHECK_THROWS(
+        cu::DeviceMemory(bytesize, CU_MEMORYTYPE_DEVICE, CU_MEM_ATTACH_GLOBAL));
+    CHECK_THROWS(
+        cu::DeviceMemory(bytesize, CU_MEMORYTYPE_DEVICE, CU_MEM_ATTACH_HOST));
+  }
 }

--- a/tests/test_vector_add.cpp
+++ b/tests/test_vector_add.cpp
@@ -84,9 +84,9 @@ TEST_CASE("Vector add") {
     cu::DeviceMemory d_b(bytesize, CU_MEMORYTYPE_UNIFIED, CU_MEM_ATTACH_HOST);
     cu::DeviceMemory d_c(bytesize, CU_MEMORYTYPE_UNIFIED, CU_MEM_ATTACH_HOST);
 
-    float *h_a = reinterpret_cast<float *>(static_cast<CUdeviceptr>(d_a));
-    float *h_b = reinterpret_cast<float *>(static_cast<CUdeviceptr>(d_b));
-    float *h_c = reinterpret_cast<float *>(static_cast<CUdeviceptr>(d_c));
+    float *h_a = d_a;
+    float *h_b = d_b;
+    float *h_c = d_c;
     std::vector<float> reference_c(N);
 
     initialize_arrays(h_a, h_b, h_c, reference_c.data(), N);
@@ -108,9 +108,9 @@ TEST_CASE("Vector add") {
       cu::DeviceMemory d_c(bytesize, CU_MEMORYTYPE_UNIFIED,
                            CU_MEM_ATTACH_GLOBAL);
 
-      float *h_a = reinterpret_cast<float *>(static_cast<CUdeviceptr>(d_a));
-      float *h_b = reinterpret_cast<float *>(static_cast<CUdeviceptr>(d_b));
-      float *h_c = reinterpret_cast<float *>(static_cast<CUdeviceptr>(d_c));
+      float *h_a = d_a;
+      float *h_b = d_b;
+      float *h_c = d_c;
       std::vector<float> reference_c(N);
 
       initialize_arrays(h_a, h_b, h_c, reference_c.data(), N);

--- a/tests/test_vector_add.cpp
+++ b/tests/test_vector_add.cpp
@@ -120,7 +120,7 @@ TEST_CASE("Vector add") {
       stream.memPrefetchAsync(d_a, bytesize, device);
       stream.memPrefetchAsync(d_b, bytesize, device);
       stream.launchKernel(function, 1, 1, 1, N, 1, 1, 0, parameters);
-      stream.memPrefetchAsync(d_c, bytesize, CU_DEVICE_CPU);
+      stream.memPrefetchAsync(d_c, bytesize);
       stream.synchronize();
 
       check_arrays_equal(h_c, reference_c.data(), N);

--- a/tests/test_vector_add.cpp
+++ b/tests/test_vector_add.cpp
@@ -78,4 +78,24 @@ TEST_CASE("Vector add") {
 
     check_arrays_equal(h_c, reference_c.data(), N);
   }
+
+  SECTION("Run kenrel with managed memory") {
+    cu::DeviceMemory d_a(bytesize, CU_MEMORYTYPE_UNIFIED, CU_MEM_ATTACH_HOST);
+    cu::DeviceMemory d_b(bytesize, CU_MEMORYTYPE_UNIFIED, CU_MEM_ATTACH_HOST);
+    cu::DeviceMemory d_c(bytesize, CU_MEMORYTYPE_UNIFIED, CU_MEM_ATTACH_HOST);
+
+    float *h_a = reinterpret_cast<float *>(static_cast<CUdeviceptr>(d_a));
+    float *h_b = reinterpret_cast<float *>(static_cast<CUdeviceptr>(d_b));
+    float *h_c = reinterpret_cast<float *>(static_cast<CUdeviceptr>(d_c));
+    std::vector<float> reference_c(N);
+
+    initialize_arrays(h_a, h_b, h_c, reference_c.data(), N);
+
+    std::vector<const void *> parameters = {d_c.parameter(), d_a.parameter(),
+                                            d_b.parameter(), &N};
+    stream.launchKernel(function, 1, 1, 1, N, 1, 1, 0, parameters);
+    stream.synchronize();
+
+    check_arrays_equal(h_c, reference_c.data(), N);
+  }
 }

--- a/tests/test_vector_add.cpp
+++ b/tests/test_vector_add.cpp
@@ -117,10 +117,10 @@ TEST_CASE("Vector add") {
 
       std::vector<const void *> parameters = {d_c.parameter(), d_a.parameter(),
                                               d_b.parameter(), &N};
-      stream.memPrefetchAsync(d_a, device, bytesize);
-      stream.memPrefetchAsync(d_b, device, bytesize);
+      stream.memPrefetchAsync(d_a, bytesize, device);
+      stream.memPrefetchAsync(d_b, bytesize, device);
       stream.launchKernel(function, 1, 1, 1, N, 1, 1, 0, parameters);
-      stream.memPrefetchAsync(d_c, CU_DEVICE_CPU, bytesize);
+      stream.memPrefetchAsync(d_c, bytesize, CU_DEVICE_CPU);
       stream.synchronize();
 
       check_arrays_equal(h_c, reference_c.data(), N);


### PR DESCRIPTION
**Description**

There are many ways to mix and match different types of CUDA memory. As preparation for this PR, an (performance) evaluation of different strategies was conducted, the findings are summarized below:
1. The use of `cu::HostMemory` and `cu::DeviceMemory` with explicit memory copies provides the best performance, but is also the most verbose.
2. Mapped memory (already supported in cudawrappers) allows addressing host memory on the GPU, which allows for simple code, but it performs rather poorly.
3. Managed memory (also known as unified memory), provides better performance and given the user the option to control data movement by prefetching to either host or device memory. When like option 1, performance is only slightly lower than.
With the changes in this MR, support for option 3 is added.

To be specific, the `cu::DeviceMemory` constructor can now also be used to allocate managed memory by passing `CU_MEMORYTYPE_UNIFIED` as `CUmemorytype` argument and optionally also some flags. This change is transparent to pre-existing code by having `CU_MEMORYTYPE_DEVICE` as the default `CUmemorytype` and default `flags = 0`.
Additionally, `cu::Stream::memPrefetchAsync` is added to expose the `cuMemPrefetchAsync` function.

The new functionality is tested in new sections of the `test_vector_add` test.


**Related issues**:

- https://github.com/nlesc-recruit/cudawrappers/issues/173

**Instructions to review the pull request**

- Check that CHANGELOG.md has been updated if necessary

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```
-->

<!--
Review online.
-->
