### PR TITLE
Add lib prefix to shared libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - The vector_add example has now become a test
+- Added `lib` prefix to shared libraries
 
 ### Removed
 - `getDevice` function of `Context`, use `Device` constructor instead

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ foreach(component ${COMPONENTS})
                             include/${PROJECT_NAME}/${component}.hpp
   )
   # Add the project name as a prefix to the output libraries
-  set_target_properties(${component} PROPERTIES PREFIX ${PROJECT_NAME}-)
+  set_target_properties(${component} PROPERTIES PREFIX lib${PROJECT_NAME}-)
   # Add includes
   target_include_directories(
     ${component}


### PR DESCRIPTION
**Description**

Add `lib` prefix to the name of shared libraries. E.g. `cudawrappers-cu.so` is now named `libcudawrappers-cu.so`.

**Related issues**:

- https://github.com/nlesc-recruit/cudawrappers/issues/196

**Instructions to review the pull request**

- Check that CHANGELOG.md has been updated if necessary

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```
-->

<!--
Review online.
-->
