### PR TITLE
Add missing include of stdexcept header

### DIFF
--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -5,6 +5,7 @@
 #include <cstddef>
 #include <exception>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>


### PR DESCRIPTION
**Description**

On Ubuntu 22.04 with gcc 11.4.0, compilation fails due to a missing include in `cu.hpp`

