### PR TITLE
Update array equality check

### DIFF
--- a/tests/test_vector_add.cpp
+++ b/tests/test_vector_add.cpp
@@ -9,10 +9,13 @@
 #include <cudawrappers/cu.hpp>
 #include <cudawrappers/nvrtc.hpp>
 
-void check_arrays_equal(const float *a, const float *b, size_t n) {
+bool arrays_equal(const float *a, const float *b, size_t n) {
   for (size_t i = 0; i < n; i++) {
-    CHECK(a[i] == Approx(b[i]).epsilon(1e-6));
+    if (a[i] != Approx(b[i]).epsilon(1e-6)) {
+      return false;
+    }
   }
+  return true;
 }
 
 void initialize_arrays(float *a, float *b, float *c, float *r, int N) {
@@ -76,7 +79,7 @@ TEST_CASE("Vector add") {
     stream.memcpyDtoHAsync(h_c, d_c, bytesize);
     stream.synchronize();
 
-    check_arrays_equal(h_c, reference_c.data(), N);
+    CHECK(arrays_equal(h_c, reference_c.data(), N));
   }
 
   SECTION("Run kernel with managed memory") {
@@ -96,7 +99,7 @@ TEST_CASE("Vector add") {
     stream.launchKernel(function, 1, 1, 1, N, 1, 1, 0, parameters);
     stream.synchronize();
 
-    check_arrays_equal(h_c, reference_c.data(), N);
+    CHECK(arrays_equal(h_c, reference_c.data(), N));
   }
 
   SECTION("Run kernel with managed memory and prefetch") {
@@ -123,7 +126,7 @@ TEST_CASE("Vector add") {
       stream.memPrefetchAsync(d_c, bytesize);
       stream.synchronize();
 
-      check_arrays_equal(h_c, reference_c.data(), N);
+      CHECK(arrays_equal(h_c, reference_c.data(), N));
     }
   }
 


### PR DESCRIPTION
**Description**

In `test_vector_add`, two arrays of floating-point values are compared for equality, calling Catch2's `CHECK` for every element. Unfortunately, and unlike other frameworks, Catch2 doesn't seem to natively support comparing arrays of floating-point numbers. Still, the current method is a bit overkill, and the code is therefore updated so that just one `CHECK` per test case is needed. 
