### PR TITLE
Move tests to correct program

### DIFF
--- a/tests/test_cu.cpp
+++ b/tests/test_cu.cpp
@@ -156,4 +156,19 @@ TEST_CASE("Test zeroing cu::DeviceMemory", "[zero]") {
     float* ptr = mem;
     CHECK_NOTHROW(ptr[0] = 42.f);
   }
+
+  SECTION("Test cu::DeviceMemory with invalid CUmemorytype") {
+    const size_t size = 1024;
+    CHECK_THROWS(cu::DeviceMemory(size, CU_MEMORYTYPE_ARRAY));
+    CHECK_THROWS(cu::DeviceMemory(size, CU_MEMORYTYPE_HOST));
+  }
+
+  SECTION("Test cu::DeviceMemory with CU_MEMORYTYPE_DEVICE and flags") {
+    const size_t size = 1024;
+    CHECK_NOTHROW(cu::DeviceMemory(size, CU_MEMORYTYPE_DEVICE, 0));
+    CHECK_THROWS(
+        cu::DeviceMemory(size, CU_MEMORYTYPE_DEVICE, CU_MEM_ATTACH_GLOBAL));
+    CHECK_THROWS(
+        cu::DeviceMemory(size, CU_MEMORYTYPE_DEVICE, CU_MEM_ATTACH_HOST));
+  }
 }

--- a/tests/test_vector_add.cpp
+++ b/tests/test_vector_add.cpp
@@ -129,17 +129,4 @@ TEST_CASE("Vector add") {
       CHECK(arrays_equal(h_c, reference_c.data(), N));
     }
   }
-
-  SECTION("Pass invalid CUmemorytype to cu::DeviceMemory constructor") {
-    CHECK_THROWS(cu::DeviceMemory(bytesize, CU_MEMORYTYPE_ARRAY));
-    CHECK_THROWS(cu::DeviceMemory(bytesize, CU_MEMORYTYPE_HOST));
-  }
-
-  SECTION("Pass flags with CU_MEMORYTYPE_DEVICE") {
-    CHECK_NOTHROW(cu::DeviceMemory(bytesize, CU_MEMORYTYPE_DEVICE, 0));
-    CHECK_THROWS(
-        cu::DeviceMemory(bytesize, CU_MEMORYTYPE_DEVICE, CU_MEM_ATTACH_GLOBAL));
-    CHECK_THROWS(
-        cu::DeviceMemory(bytesize, CU_MEMORYTYPE_DEVICE, CU_MEM_ATTACH_HOST));
-  }
 }


### PR DESCRIPTION
**Description**

Some tests for `cu::DeviceMemory` have accidentally ended up in `test_vector_add`, while these should have been added to `test_cu`. Both the author and reviewer missed this, but it is corrected now.