### PR TITLE
Add functions to asynchronously allocate and free device memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - cu::HostMemory constuctor for pre-allocated memory
 - cu::DeviceMemory constructor for managed memory
 - cu::Stream::cuMemPrefetchAsync for pre-fetching of managed memory
+- cu::Stream::memAllocAsync and cu::Stream::memFreeAsync
+- cu::Context::getFreeMemory and cu::Context::getTotalMemory
 
 ### Changed
 - The vector_add example has now become a test

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -209,6 +209,20 @@ class Context : public Wrapper<CUcontext> {
     setLimit(limit, value);
   }
 
+  size_t getFreeMemory() const {
+    size_t free;
+    size_t total;
+    checkCudaCall(cuMemGetInfo(&free, &total));
+    return free;
+  }
+
+  size_t getTotalMemory() const {
+    size_t free;
+    size_t total;
+    checkCudaCall(cuMemGetInfo(&free, &total));
+    return total;
+  }
+
   static void synchronize() { checkCudaCall(cuCtxSynchronize()); }
 
  private:

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -432,6 +432,16 @@ class Stream : public Wrapper<CUstream> {
 
   explicit Stream(CUstream stream) : Wrapper<CUstream>(stream) {}
 
+  DeviceMemory memAllocAsync(size_t size) {
+    CUdeviceptr ptr;
+    checkCudaCall(cuMemAllocAsync(&ptr, size, _obj));
+    return DeviceMemory(ptr);
+  }
+
+  void memFreeAsync(DeviceMemory &devMem) {
+    checkCudaCall(cuMemFreeAsync(devMem, _obj));
+  }
+
   void memcpyHtoHAsync(void *dstPtr, const void *srcPtr, size_t size) {
     checkCudaCall(cuMemcpyAsync(reinterpret_cast<CUdeviceptr>(dstPtr),
                                 reinterpret_cast<CUdeviceptr>(srcPtr), size,

--- a/tests/test_vector_add.cpp
+++ b/tests/test_vector_add.cpp
@@ -130,6 +130,39 @@ TEST_CASE("Vector add") {
     }
   }
 
+  SECTION("Run kernel with asynchronously allocated memory") {
+    cu::HostMemory h_a(bytesize);
+    cu::HostMemory h_b(bytesize);
+    cu::HostMemory h_c(bytesize);
+    std::vector<float> reference_c(N);
+
+    initialize_arrays(static_cast<float *>(h_a), static_cast<float *>(h_b),
+                      static_cast<float *>(h_c), reference_c.data(), N);
+
+    const size_t memory_free = context.getFreeMemory();
+
+    cu::DeviceMemory d_a = stream.memAllocAsync(bytesize);
+    cu::DeviceMemory d_b = stream.memAllocAsync(bytesize);
+    cu::DeviceMemory d_c = stream.memAllocAsync(bytesize);
+
+    stream.memcpyHtoDAsync(d_a, h_a, bytesize);
+    stream.memcpyHtoDAsync(d_b, h_b, bytesize);
+    std::vector<const void *> parameters = {d_c.parameter(), d_a.parameter(),
+                                            d_b.parameter(), &N};
+    stream.launchKernel(function, 1, 1, 1, N, 1, 1, 0, parameters);
+    stream.memcpyDtoHAsync(h_c, d_c, bytesize);
+    stream.memFreeAsync(d_a);
+    stream.memFreeAsync(d_b);
+    stream.memFreeAsync(d_c);
+    stream.synchronize();
+
+    if (!device.getAttribute(CU_DEVICE_ATTRIBUTE_INTEGRATED)) {
+      CHECK(memory_free == context.getFreeMemory());
+    }
+
+    CHECK(arrays_equal(h_c, reference_c.data(), N));
+  }
+
   SECTION("Pass invalid CUmemorytype to cu::DeviceMemory constructor") {
     CHECK_THROWS(cu::DeviceMemory(bytesize, CU_MEMORYTYPE_ARRAY));
     CHECK_THROWS(cu::DeviceMemory(bytesize, CU_MEMORYTYPE_HOST));

--- a/tests/test_vector_add.cpp
+++ b/tests/test_vector_add.cpp
@@ -157,9 +157,9 @@ TEST_CASE("Vector add") {
     stream.synchronize();
 
     if (!device.getAttribute(CU_DEVICE_ATTRIBUTE_INTEGRATED)) {
-      // The following CHECK is disabled since we cannot make sure that the test
-      // is using the GPU exclusively CHECK(memory_free ==
-      // context.getFreeMemory());
+      // The following CHECK is disabled since we cannot make
+      // sure that the test is using the GPU exclusively:
+      // CHECK(memory_free == context.getFreeMemory());
     }
 
     CHECK(arrays_equal(h_c, reference_c.data(), N));

--- a/tests/test_vector_add.cpp
+++ b/tests/test_vector_add.cpp
@@ -157,8 +157,9 @@ TEST_CASE("Vector add") {
     stream.synchronize();
 
     if (!device.getAttribute(CU_DEVICE_ATTRIBUTE_INTEGRATED)) {
-      // The following CHECK is disabled since we cannot make sure that the test is using the GPU exclusively
-      // CHECK(memory_free == context.getFreeMemory());
+      // The following CHECK is disabled since we cannot make sure that the test
+      // is using the GPU exclusively CHECK(memory_free ==
+      // context.getFreeMemory());
     }
 
     CHECK(arrays_equal(h_c, reference_c.data(), N));

--- a/tests/test_vector_add.cpp
+++ b/tests/test_vector_add.cpp
@@ -157,7 +157,8 @@ TEST_CASE("Vector add") {
     stream.synchronize();
 
     if (!device.getAttribute(CU_DEVICE_ATTRIBUTE_INTEGRATED)) {
-      CHECK(memory_free == context.getFreeMemory());
+      // The following CHECK is disabled since we cannot make sure that the test is using the GPU exclusively
+      // CHECK(memory_free == context.getFreeMemory());
     }
 
     CHECK(arrays_equal(h_c, reference_c.data(), N));


### PR DESCRIPTION
**Description**

`Stream::memAllocAsync` and `Stream::memFreeAsync` are added. To test this new functionality, `Context::getFreeMemory` (and for completeness `Context::getTotalMemory`) have also been added so that a test can be performed to see if the free device memory before and after using the asynchronous allocation remains the same. The test is not performed on devices with integrated memory, as we have no control over other processes allocating/free-ing the memory.

**Instructions to review the pull request**

- Check that CHANGELOG.md has been updated if necessary

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```
-->

<!--
Review online.
-->
