### PR TITLE
Fix kernel embedding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 ### Changed
+- Replaced `include_cuda_code` helper with `target_embed_source`
 ### Removed
 
 ## [0.5.0] - 2023-09-25

--- a/cmake/helper.cmake
+++ b/cmake/helper.cmake
@@ -1,7 +1,7 @@
 # Make it possible to embed a source file in a library, and link it to a target.
 # E.g. to link <kernel.cu> into target <example_program>, use
 # target_embed_source(example_program, kernel.cu). This will expose symbols
-# _binary_kernel_cu_start and _binary_ls_kernel_cu_end.
+# _binary_kernel_cu_start and _binary_kernel_cu_end.
 function(target_embed_source target input_file)
   # Strip the path and extension from input_file
   get_filename_component(NAME ${input_file} NAME_WLE)

--- a/cmake/helper.cmake
+++ b/cmake/helper.cmake
@@ -12,3 +12,19 @@ function(include_cuda_code target input_file)
     ${target} PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/${output_subdir}"
   )
 endfunction(include_cuda_code)
+
+function(target_embed_source target input_file)
+  get_filename_component(NAME ${input_file} NAME_WLE)
+  add_custom_command(
+    OUTPUT ${NAME}.o
+    COMMAND ld ARGS -r -b binary -o ${CMAKE_CURRENT_BINARY_DIR}/${NAME}.o
+            ${input_file}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    DEPENDS ${input_file}
+  )
+  if(NOT TARGET ${NAME})
+    add_library(${NAME} STATIC ${NAME}.o)
+    set_target_properties(${NAME} PROPERTIES LINKER_LANGUAGE CXX)
+  endif()
+  target_link_libraries(${target} PRIVATE ${NAME})
+endfunction()

--- a/cmake/helper.cmake
+++ b/cmake/helper.cmake
@@ -12,6 +12,7 @@ function(target_embed_source target input_file)
             ${input_file}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     DEPENDS ${input_file}
+    COMMENT "Creating object file for ${input_file}"
   )
   if(NOT TARGET ${NAME})
     # Create a proper static library for the .o file

--- a/cmake/helper.cmake
+++ b/cmake/helper.cmake
@@ -1,18 +1,3 @@
-# Make it possible to #include cuda source code
-function(include_cuda_code target input_file)
-  # Save file containing cuda code as a C++ raw string literal
-  file(READ ${input_file} content)
-  set(delim "for_c++_include")
-  set(content "R\"${delim}(\n${content})${delim}\"")
-  set(output_file "${CMAKE_CURRENT_BINARY_DIR}/${input_file}")
-  file(WRITE ${output_file} "${content}")
-  # Add save path to the include directories
-  get_filename_component(output_subdir ${input_file} DIRECTORY)
-  target_include_directories(
-    ${target} PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/${output_subdir}"
-  )
-endfunction(include_cuda_code)
-
 # Make it possible to embed a source file in a library, and link it to a target.
 # E.g. to link <kernel.cu> into target <example_program>, use
 # target_embed_source(example_program, kernel.cu). This will expose symbols

--- a/cmake/helper.cmake
+++ b/cmake/helper.cmake
@@ -13,8 +13,14 @@ function(include_cuda_code target input_file)
   )
 endfunction(include_cuda_code)
 
+# Make it possible to embed a source file in a library, and link it to a target.
+# E.g. to link <kernel.cu> into target <example_program>, use
+# target_embed_source(example_program, kernel.cu). This will expose symbols
+# _binary_kernel_cu_start and _binary_ls_kernel_cu_end.
 function(target_embed_source target input_file)
+  # Strip the path and extension from input_file
   get_filename_component(NAME ${input_file} NAME_WLE)
+  # Link the input_file into an object file
   add_custom_command(
     OUTPUT ${NAME}.o
     COMMAND ld ARGS -r -b binary -o ${CMAKE_CURRENT_BINARY_DIR}/${NAME}.o
@@ -23,8 +29,10 @@ function(target_embed_source target input_file)
     DEPENDS ${input_file}
   )
   if(NOT TARGET ${NAME})
+    # Create a proper static library for the .o file
     add_library(${NAME} STATIC ${NAME}.o)
     set_target_properties(${NAME} PROPERTIES LINKER_LANGUAGE CXX)
   endif()
+  # Link the static library to the target
   target_link_libraries(${target} PRIVATE ${NAME})
 endfunction()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,8 +26,9 @@ set(LINK_LIBRARIES Catch2::Catch2 cudawrappers::cu)
 
 target_link_libraries(test_cu PUBLIC ${LINK_LIBRARIES})
 
-include_cuda_code(test_nvrtc kernels/vector_add_kernel.cu)
 target_link_libraries(test_nvrtc PUBLIC ${LINK_LIBRARIES} cudawrappers::nvrtc)
+
+target_embed_source(test_nvrtc kernels/vector_add_kernel.cu)
 
 target_link_libraries(test_cufft PUBLIC ${LINK_LIBRARIES} cudawrappers::cufft)
 

--- a/tests/test_nvrtc.cpp
+++ b/tests/test_nvrtc.cpp
@@ -28,10 +28,12 @@ TEST_CASE("Test nvrtc::Program", "[program]") {
   }
 }
 
+extern const char _binary_kernels_vector_add_kernel_cu_start,
+    _binary_kernels_vector_add_kernel_cu_end;
+
 TEST_CASE("Test nvrtc::Program embedded source", "[program]") {
-  const std::string kernel =
-#include "vector_add_kernel.cu"
-      ;
+  const std::string kernel(&_binary_kernels_vector_add_kernel_cu_start,
+                           &_binary_kernels_vector_add_kernel_cu_end);
   nvrtc::Program program(kernel, "vector_add_kernel.cu");
 
   SECTION("Test Program.compile") {


### PR DESCRIPTION
**Description**

`test_nvrtc` has a test case where the kernel source is embedded into the test source using a `include_cuda_code` helper function. This function doesn't work correctly when the source file is changed. It is now replaced with the `target_embed_source` helper function, which uses `ld` to link a static object with the code embedded. `test_nvrtc` is updated to demonstrate its use.

TODO:

- [x] Update `CHANGELOG.md`
- [ ] As soon as https://github.com/nlesc-recruit/cudawrappers/pull/220 is merged, export this function in the CMake config file so that it can also used by projects that use cudawrappers.