### PR TITLE
Move asynchronous zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 ### Changed
 - Made the library header only
+- Moved asynchronous ::zero from Device to Stream
 - Replaced `include_cuda_code` helper with `target_embed_source`
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 ### Changed
 - Made the library header only
-- Moved asynchronous ::zero from Device to Stream
+- Moved asynchronous `::zero` from `Device` to `Stream`
 - Replaced `include_cuda_code` helper with `target_embed_source`
 ### Removed
 

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -415,8 +415,6 @@ class DeviceMemory : public Wrapper<CUdeviceptr> {
 
   void zero(size_t size) { checkCudaCall(cuMemsetD8(_obj, 0, size)); }
 
-  void zero(size_t size, Stream &stream);
-
   const void *parameter()
       const  // used to construct parameter list for launchKernel();
   {
@@ -484,6 +482,10 @@ class Stream : public Wrapper<CUstream> {
     checkCudaCall(cuMemPrefetchAsync(devPtr, size, dstDevice, _obj));
   }
 
+  void zero(CUdeviceptr devPtr, size_t size) {
+    checkCudaCall(cuMemsetD8Async(devPtr, 0, size, _obj));
+  }
+
   void launchKernel(Function &function, unsigned gridX, unsigned gridY,
                     unsigned gridZ, unsigned blockX, unsigned blockY,
                     unsigned blockZ, unsigned sharedMemBytes,
@@ -533,10 +535,6 @@ class Stream : public Wrapper<CUstream> {
     checkCudaCall(cuStreamWriteValue32(_obj, addr, value, flags));
   }
 };
-
-inline void DeviceMemory::zero(size_t size, Stream &stream) {
-  checkCudaCall(cuMemsetD8Async(_obj, 0, size, stream));
-}
 
 inline void Event::record(Stream &stream) {
   checkCudaCall(cuEventRecord(_obj, stream._obj));

--- a/tests/test_cu.cpp
+++ b/tests/test_cu.cpp
@@ -87,7 +87,7 @@ TEST_CASE("Test zeroing cu::DeviceMemory", "[zero]") {
 
     cu::Stream stream;
     stream.memcpyHtoDAsync(mem, src, size);
-    mem.zero(size, stream);
+    stream.zero(mem, size);
     stream.memcpyDtoHAsync(tgt, mem, size);
     stream.synchronize();
 


### PR DESCRIPTION
**Description**

As described in https://github.com/nlesc-recruit/cudawrappers/issues/225, the asynchronous `::zero` function should be part of `Stream` (like the asynchronous memory allocation functions), instead of part of `DeviceMemory`.

**Related issues**:

- https://github.com/nlesc-recruit/cudawrappers/issues/225

**Instructions to review the pull request**

- Check that CHANGELOG.md has been updated if necessary

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```
-->

<!--
Review online.
-->
