### PR TITLE
Fix variable not quoted can cause errors in other CMakefiles.txt

### DIFF
--- a/cmake/cudawrappers-config.cmake
+++ b/cmake/cudawrappers-config.cmake
@@ -7,7 +7,7 @@ set(CUDA_MIN_VERSION 10.0)
 if(${CUDAWRAPPERS_INSTALLED})
   find_package(CUDAToolkit ${CUDA_MIN_VERSION} REQUIRED)
 else()
-  if($CUDAToolkit_FOUND)
+  if(${CUDAToolkit_FOUND})
     if(${CUDAToolkit_VERSION_MAJOR} LESS ${CUDA_MIN_VERSION})
       message(FATAL_ERROR "Insufficient CUDA version: " ${CUDAToolkit_VERSION}
                           " < " ${CUDA_MIN_VERSION}


### PR DESCRIPTION
Because of an earlier change now in this CMakefile it is checked if the variable is defined. However, the variable is not properly escaped and it could cause issues.


