### PR TITLE
Pass cu:: objects wherever appropriate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Made the library header only
 - Moved asynchronous `::zero` from `Device` to `Stream`
 - Replaced `include_cuda_code` helper with `target_embed_source`
+- Changed some arguments from native to wrapped type
 ### Removed
 
 ## [0.5.0] - 2023-09-25

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -332,7 +332,7 @@ class Module : public Wrapper<CUmodule> {
     });
   }
 
-  explicit Module(CUmodule &module) : Wrapper(module) {}
+  explicit Module(Module &module) : Wrapper(module) {}
 
   CUdeviceptr getGlobal(const char *name) const {
     CUdeviceptr deviceptr{};
@@ -465,24 +465,28 @@ class Stream : public Wrapper<CUstream> {
                                 _obj));
   }
 
-  void memcpyHtoDAsync(CUdeviceptr devPtr, const void *hostPtr, size_t size) {
+  void memcpyHtoDAsync(DeviceMemory &devPtr, const void *hostPtr, size_t size) {
     checkCudaCall(cuMemcpyHtoDAsync(devPtr, hostPtr, size, _obj));
   }
 
-  void memcpyDtoHAsync(void *hostPtr, CUdeviceptr devPtr, size_t size) {
+  void memcpyDtoHAsync(void *hostPtr, DeviceMemory &devPtr, size_t size) {
     checkCudaCall(cuMemcpyDtoHAsync(hostPtr, devPtr, size, _obj));
   }
 
-  void memcpyDtoDAsync(CUdeviceptr dstPtr, CUdeviceptr srcPtr, size_t size) {
+  void memcpyDtoDAsync(DeviceMemory &dstPtr, DeviceMemory &srcPtr,
+                       size_t size) {
     checkCudaCall(cuMemcpyAsync(dstPtr, srcPtr, size, _obj));
   }
 
-  void memPrefetchAsync(CUdeviceptr devPtr, size_t size,
-                        CUdevice dstDevice = CU_DEVICE_CPU) {
+  void memPrefetchAsync(DeviceMemory &devPtr, size_t size) {
+    checkCudaCall(cuMemPrefetchAsync(devPtr, size, CU_DEVICE_CPU, _obj));
+  }
+
+  void memPrefetchAsync(DeviceMemory &devPtr, size_t size, Device &dstDevice) {
     checkCudaCall(cuMemPrefetchAsync(devPtr, size, dstDevice, _obj));
   }
 
-  void zero(CUdeviceptr devPtr, size_t size) {
+  void zero(DeviceMemory &devPtr, size_t size) {
     checkCudaCall(cuMemsetD8Async(devPtr, 0, size, _obj));
   }
 

--- a/include/cudawrappers/cufft.hpp
+++ b/include/cudawrappers/cufft.hpp
@@ -107,20 +107,13 @@ class FFT {
 
   ~FFT() { checkCuFFTCall(cufftDestroy(plan_)); }
 
-  void setStream(CUstream stream) {
+  void setStream(cu::Stream &stream) {
     checkCuFFTCall(cufftSetStream(plan_, stream));
   }
 
-  void execute(cu::DeviceMemory &in, cu::DeviceMemory &out,
-               int direction = CUFFT_FORWARD) {
+  void execute(cu::DeviceMemory &in, cu::DeviceMemory &out, int direction) {
     void *in_ptr = reinterpret_cast<void *>(static_cast<CUdeviceptr>(in));
     void *out_ptr = reinterpret_cast<void *>(static_cast<CUdeviceptr>(out));
-    checkCuFFTCall(cufftXtExec(plan_, in_ptr, out_ptr, direction));
-  }
-
-  void execute(CUdeviceptr in, CUdeviceptr out, int direction) {
-    void *in_ptr = reinterpret_cast<void *>(in);
-    void *out_ptr = reinterpret_cast<void *>(out);
     checkCuFFTCall(cufftXtExec(plan_, in_ptr, out_ptr, direction));
   }
 


### PR DESCRIPTION
**Description**

In parts of the API the arguments were declared as e.g. `CUdeviceptr` instead of `cu::DeviceMemory&`, this is now fixed.

**Related issues**:

- N.A.

**Instructions to review the pull request**

- Check that CHANGELOG.md has been updated if necessary

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```
-->

<!--
Review online.
-->
