### PR TITLE
Aartfaac fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
+- Added `cu::Context::getDevice()`
 ### Changed
+- Fixed the `cu::Module(CUmodule&)` constructor
 ### Removed
 
 ## [0.6.0] - 2023-10-06

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -341,7 +341,7 @@ class Module : public Wrapper<CUmodule> {
     });
   }
 
-  explicit Module(Module &module) : Wrapper(module) {}
+  explicit Module(CUmodule &module) : Wrapper(module) {}
 
   CUdeviceptr getGlobal(const char *name) const {
     CUdeviceptr deviceptr{};

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -90,6 +90,9 @@ class Device : public Wrapper<CUdevice> {
 
   explicit Device(int ordinal) { checkCudaCall(cuDeviceGet(&_obj, ordinal)); }
 
+  struct CUdeviceArg {}; // int and CUdevice are the same type, but we need two constructors
+  Device(CUdeviceArg, CUdevice device) : Wrapper(device) {}
+
   int getAttribute(CUdevice_attribute attribute) const {
     int value{};
     checkCudaCall(cuDeviceGetAttribute(&value, attribute, _obj));
@@ -192,6 +195,12 @@ class Context : public Wrapper<CUcontext> {
 
   void setSharedMemConfig(CUsharedconfig config) {
     checkCudaCall(cuCtxSetSharedMemConfig(config));
+  }
+
+  static Device getDevice() {
+    CUdevice device;
+    checkCudaCall(cuCtxGetDevice(&device));
+    return Device(Device::CUdeviceArg(), device);
   }
 
   static size_t getLimit(CUlimit limit) {

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -90,7 +90,8 @@ class Device : public Wrapper<CUdevice> {
 
   explicit Device(int ordinal) { checkCudaCall(cuDeviceGet(&_obj, ordinal)); }
 
-  struct CUdeviceArg {}; // int and CUdevice are the same type, but we need two constructors
+  struct CUdeviceArg {
+  };  // int and CUdevice are the same type, but we need two constructors
   Device(CUdeviceArg, CUdevice device) : Wrapper(device) {}
 
   int getAttribute(CUdevice_attribute attribute) const {

--- a/tests/test_cu.cpp
+++ b/tests/test_cu.cpp
@@ -22,10 +22,15 @@ TEST_CASE("Test cu::Device", "[device]") {
 
 TEST_CASE("Test context::getDevice", "[device]") {
   cu::init();
+
+  SECTION("Test before initialization") {
+    CHECK_THROWS(cu::Context::getCurrent().getDevice());
+  }
+
   cu::Device device(0);
   cu::Context context(CU_CTX_SCHED_BLOCKING_SYNC, device);
 
-  SECTION("Test Device.getName") {
+  SECTION("Test after initialization") {
     CHECK(device.getName() == cu::Context::getCurrent().getDevice().getName());
   }
 }

--- a/tests/test_cu.cpp
+++ b/tests/test_cu.cpp
@@ -20,6 +20,16 @@ TEST_CASE("Test cu::Device", "[device]") {
   }
 }
 
+TEST_CASE("Test context::getDevice", "[device]") {
+  cu::init();
+  cu::Device device(0);
+  cu::Context context(CU_CTX_SCHED_BLOCKING_SYNC, device);
+
+  SECTION("Test Device.getName") {
+    CHECK(device.getName() == cu::Context::getCurrent().getDevice().getName());
+  }
+}
+
 TEST_CASE("Test copying cu::DeviceMemory and cu::HostMemory using cu::Stream",
           "[memcpy]") {
   cu::init();


### PR DESCRIPTION
**Description**

Adds cu::Context::getDevice() and fixes the cu::Module(CUmodule) constructor, necessary for use by the AARTFAAC correlator

**Related issues**:

- ...

**Instructions to review the pull request**

- Check that CHANGELOG.md has been updated if necessary

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```
-->

<!--
Review online.
-->
