### PR TITLE
Added new functions needed by the DPDK correlator.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Added `cu::Context::getDevice()`
 - Added `cu::Stream::getContext()`
-- Added overloaded versions of cu::Stream::memcpyDtoHAsync and cu::Stream::memcpyDtoHAsync that take CUdeviceptr as an argument
+- Added overloaded versions of `cu::Stream::memcpyDtoHAsync` and `cu::Stream::memcpyDtoHAsync` that take CUdeviceptr as an argument
 ### Changed
 - Fixed the `cu::Module(CUmodule&)` constructor
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Added `cu::Context::getDevice()`
+- Added `cu::Stream::getContext()`
+- Added overloaded versions of cu::Stream::memcpyDtoHAsync and cu::Stream::memcpyDtoHAsync that take CUdeviceptr as an argument
 ### Changed
 - Fixed the `cu::Module(CUmodule&)` constructor
 ### Removed

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -479,7 +479,15 @@ class Stream : public Wrapper<CUstream> {
     checkCudaCall(cuMemcpyHtoDAsync(devPtr, hostPtr, size, _obj));
   }
 
-  void memcpyDtoHAsync(void *hostPtr, DeviceMemory &devPtr, size_t size) {
+  void memcpyHtoDAsync(CUdeviceptr devPtr, const void *hostPtr, size_t size) {
+    checkCudaCall(cuMemcpyHtoDAsync(devPtr, hostPtr, size, _obj));
+  }
+
+  void memcpyDtoHAsync(void *hostPtr, const DeviceMemory &devPtr, size_t size) {
+    checkCudaCall(cuMemcpyDtoHAsync(hostPtr, devPtr, size, _obj));
+  }
+
+  void memcpyDtoHAsync(void *hostPtr, CUdeviceptr devPtr, size_t size) {
     checkCudaCall(cuMemcpyDtoHAsync(hostPtr, devPtr, size, _obj));
   }
 
@@ -547,6 +555,12 @@ class Stream : public Wrapper<CUstream> {
 
   void writeValue32(CUdeviceptr addr, cuuint32_t value, unsigned flags) {
     checkCudaCall(cuStreamWriteValue32(_obj, addr, value, flags));
+  }
+
+  Context getContext() const {
+    CUcontext context;
+    checkCudaCall(cuStreamGetCtx(_obj, &context));
+    return Context(context);
   }
 };
 


### PR DESCRIPTION
**Description**

- Added overloaded versions of cu::Stream::memcpyDtoHAsync and cu::Stream::memcpyDtoHAsync that take CUdeviceptr as an argument
- Added Stream::getContext()

**Related issues**:

- N.A.

**Instructions to review the pull request**

- Check that CHANGELOG.md has been updated if necessary

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```
-->

<!--
Review online.
-->
