### PR TITLE
Update cudawrappers to support COBALT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,16 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Added `cu::Context::getDevice()`
+- Added `cu::Module` constructor with `CUjit_option` map argument
+- Added `DeviceMemory::size`
+- Added `HostMemory::size`
+- Added `Function::launch` with dim3 arguments
+- Added `Function::name`
+
 ### Changed
 - Fixed the `cu::Module(CUmodule&)` constructor
+- Added `Function::getAttribute` is now const
+
 ### Removed
 
 ## [0.6.0] - 2023-10-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added `cu::Module` constructor with `CUjit_option` map argument
 - Added `DeviceMemory::size`
 - Added `HostMemory::size`
-- Added `Function::launch` with dim3 arguments
 - Added `Function::name`
 
 ### Changed

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -514,6 +514,13 @@ class Stream : public Wrapper<CUstream> {
                                  const_cast<void **>(&parameters[0]), nullptr));
   }
 
+  void launchKernel(Function &function, dim3 grid, dim3 block,
+                    unsigned sharedMemBytes,
+                    const std::vector<const void *> &parameters) {
+    launchKernel(function, grid.x, grid.y, grid.z, block.x, block.y, block.z,
+                 sharedMemBytes, parameters);
+  }
+
 #if CUDART_VERSION >= 9000
   void launchCooperativeKernel(Function &function, unsigned gridX,
                                unsigned gridY, unsigned gridZ, unsigned blockX,

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -359,8 +359,8 @@ class Module : public Wrapper<CUmodule> {
       values.push_back(i.second);
     }
 
-    checkCudaCall(
-        cuModuleLoadDataEx(&_obj, image, options.size(), &keys[0], &values[0]));
+    checkCudaCall(cuModuleLoadDataEx(&_obj, image, options.size(), keys.data(),
+                                     values.data()));
 
     for (size_t i = 0; i < keys.size(); ++i) {
       options[keys[i]] = values[i];

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -354,10 +354,9 @@ class Module : public Wrapper<CUmodule> {
     std::vector<CUjit_option> keys;
     std::vector<void *> values;
 
-    for (optionmap_t::const_iterator i = options.begin(); i != options.end();
-         ++i) {
-      keys.push_back(i->first);
-      values.push_back(i->second);
+    for (const std::pair<CUjit_option, void *> &i : options) {
+      keys.push_back(i.first);
+      values.push_back(i.second);
     }
 
     checkCudaCall(

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -250,7 +250,7 @@ class Context : public Wrapper<CUcontext> {
 
 class HostMemory : public Wrapper<void *> {
  public:
-  explicit HostMemory(size_t size, unsigned int flags = 0) {
+  explicit HostMemory(size_t size, unsigned int flags = 0) : _size(size) {
     checkCudaCall(cuMemHostAlloc(&_obj, size, flags));
     manager = std::shared_ptr<void *>(new (void *)(_obj), [](void **ptr) {
       cuMemFreeHost(*ptr);
@@ -258,7 +258,8 @@ class HostMemory : public Wrapper<void *> {
     });
   }
 
-  explicit HostMemory(void *ptr, size_t size, unsigned int flags = 0) {
+  explicit HostMemory(void *ptr, size_t size, unsigned int flags = 0)
+      : _size(size) {
     _obj = ptr;
     checkCudaCall(cuMemHostRegister(&_obj, size, flags));
     manager = std::shared_ptr<void *>(
@@ -269,6 +270,11 @@ class HostMemory : public Wrapper<void *> {
   operator T *() {
     return static_cast<T *>(_obj);
   }
+
+  size_t size() const { return _size; }
+
+ private:
+  size_t _size;
 };
 
 class Array : public Wrapper<CUarray> {

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -4,6 +4,7 @@
 #include <array>
 #include <cstddef>
 #include <exception>
+#include <map>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -346,6 +347,25 @@ class Module : public Wrapper<CUmodule> {
       cuModuleUnload(*ptr);
       delete ptr;
     });
+  }
+
+  typedef std::map<CUjit_option, void *> optionmap_t;
+  explicit Module(const void *image, Module::optionmap_t &options) {
+    std::vector<CUjit_option> keys;
+    std::vector<void *> values;
+
+    for (optionmap_t::const_iterator i = options.begin(); i != options.end();
+         ++i) {
+      keys.push_back(i->first);
+      values.push_back(i->second);
+    }
+
+    checkCudaCall(
+        cuModuleLoadDataEx(&_obj, image, options.size(), &keys[0], &values[0]));
+
+    for (size_t i = 0; i < keys.size(); ++i) {
+      options[keys[i]] = values[i];
+    }
   }
 
   explicit Module(CUmodule &module) : Wrapper(module) {}

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -353,7 +353,7 @@ class Module : public Wrapper<CUmodule> {
 
 class Function : public Wrapper<CUfunction> {
  public:
-  Function(const Module &module, const char *name) {
+  Function(const Module &module, const char *name) : _name(name) {
     checkCudaCall(cuModuleGetFunction(&_obj, module, name));
   }
 
@@ -368,6 +368,11 @@ class Function : public Wrapper<CUfunction> {
   void setCacheConfig(CUfunc_cache config) {
     checkCudaCall(cuFuncSetCacheConfig(_obj, config));
   }
+
+  const char *name() const { return _name; }
+
+ private:
+  const char *_name;
 };
 
 class Event : public Wrapper<CUevent> {

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -413,7 +413,8 @@ class Event : public Wrapper<CUevent> {
 class DeviceMemory : public Wrapper<CUdeviceptr> {
  public:
   explicit DeviceMemory(size_t size, CUmemorytype type = CU_MEMORYTYPE_DEVICE,
-                        unsigned int flags = 0) {
+                        unsigned int flags = 0)
+      : _size(size) {
     if (type == CU_MEMORYTYPE_DEVICE and !flags) {
       checkCudaCall(cuMemAlloc(&_obj, size));
     } else if (type == CU_MEMORYTYPE_UNIFIED) {
@@ -454,6 +455,11 @@ class DeviceMemory : public Wrapper<CUdeviceptr> {
           "Cannot return memory of type CU_MEMORYTYPE_DEVICE as pointer.");
     }
   }
+
+  size_t size() const { return _size; }
+
+ private:
+  size_t _size;
 };
 
 class Stream : public Wrapper<CUstream> {

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -359,7 +359,7 @@ class Function : public Wrapper<CUfunction> {
 
   explicit Function(CUfunction &function) : Wrapper(function) {}
 
-  int getAttribute(CUfunction_attribute attribute) {
+  int getAttribute(CUfunction_attribute attribute) const {
     int value{};
     checkCudaCall(cuFuncGetAttribute(&value, attribute, _obj));
     return value;

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -545,13 +545,6 @@ class Stream : public Wrapper<CUstream> {
                                  const_cast<void **>(&parameters[0]), nullptr));
   }
 
-  void launchKernel(Function &function, dim3 grid, dim3 block,
-                    unsigned sharedMemBytes,
-                    const std::vector<const void *> &parameters) {
-    launchKernel(function, grid.x, grid.y, grid.z, block.x, block.y, block.z,
-                 sharedMemBytes, parameters);
-  }
-
 #if CUDART_VERSION >= 9000
   void launchCooperativeKernel(Function &function, unsigned gridX,
                                unsigned gridY, unsigned gridZ, unsigned blockX,


### PR DESCRIPTION
**Description**

A number of features were found missing when integrating cudawrappers into the COBALT code:
- Module constructor with CUjit_option map argument
- DeviceMemory::size
- HostMemory::size
- Function::launch with dim3 arguments
- Function::name
- Function::getAttribute is now const

**Related issues**:

- N.A.

**Instructions to review the pull request**

- Check that CHANGELOG.md has been updated if necessary

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```
-->

<!--
Review online.
-->
