### PR TITLE
Remove <T> for Wrapper constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed the `cu::Module(CUmodule&)` constructor
 - Added `Function::getAttribute` is now const
 
+### Fixed
+- Fix compatibility with C++20 and C++23
+
 ### Removed
 
 ## [0.6.0] - 2023-10-06

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -69,17 +69,16 @@ class Wrapper {
   bool operator!=(const Wrapper<T> &other) { return _obj != other._obj; }
 
  protected:
-  Wrapper<T>() = default;
+  Wrapper() = default;
 
-  Wrapper<T>(const Wrapper<T> &other)
-      : _obj(other._obj), manager(other.manager) {}
+  Wrapper(const Wrapper<T> &other) : _obj(other._obj), manager(other.manager) {}
 
-  Wrapper<T>(Wrapper<T> &&other)
+  Wrapper(Wrapper<T> &&other)
       : _obj(other._obj), manager(std::move(other.manager)) {
     other._obj = 0;
   }
 
-  explicit Wrapper<T>(T &obj) : _obj(obj) {}
+  explicit Wrapper(T &obj) : _obj(obj) {}
 
   T _obj{};
   std::shared_ptr<T> manager;


### PR DESCRIPTION
**Description**

Compiling with C++20  or C++23 gives errors on the constructors due to `<T>`, which is no longer allowed.

Fixing it solves the compilation issue.

**Related issues**:

- N.A.

**Instructions to review the pull request**

- Check that CHANGELOG.md has been updated if necessary

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```
-->

<!--
Review online.
-->
