### PR TITLE
Add asynchronous DeviceMemory::zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added `Function::name`
 - Added `cu::Stream::getContext()`
 - Added overloaded versions of `cu::Stream::memcpyDtoHAsync` and `cu::Stream::memcpyDtoHAsync` that take CUdeviceptr as an argument
+- Added asynchronous `DeviceMemory::zero` with stream argument
 
 ### Changed
 - Fixed the `cu::Module(CUmodule&)` constructor

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -453,6 +453,10 @@ class DeviceMemory : public Wrapper<CUdeviceptr> {
     checkCudaCall(cuMemHostGetDevicePointer(&_obj, hostMemory, 0));
   }
 
+  void zero(size_t size, CUstream stream) {
+    checkCudaCall(cuMemsetD8Async(_obj, 0, size, stream));
+  }
+
   void zero(size_t size) { checkCudaCall(cuMemsetD8(_obj, 0, size)); }
 
   const void *parameter()


### PR DESCRIPTION
**Description**

Added asynchronous `DeviceMemory::zero` with stream argument. This provides a wrapper for the `cuMemsetD8Async` API call.

**Related issues**:

- N.A.

**Instructions to review the pull request**

- Check that CHANGELOG.md has been updated if necessary

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```
-->

<!--
Review online.
-->
