### PR TITLE
update links

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ The project is planning to support more of the Driver API (for fine-grained cont
 
 ## Contributing
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md) for a guide on how to contribute.
+See [CONTRIBUTING.md](https://github.com/nlesc-recruit/cudawrappers/blob/main/CONTRIBUTING.md) for a guide on how to contribute.
 
 ## Developer documentation
 
-See [README.dev.md](./README.dev.md) for documentation on setting up your development environment.
+See [README.dev.md](https://github.com/nlesc-recruit/cudawrappers/blob/main/README.dev.md) for documentation on setting up your development environment.


### PR DESCRIPTION
**Description**

<!-- Description of PR -->
This pull request fixes the deadlink issue in the documentation on readthedocs; the link to the contributing guidelines and readme dev. It uses the full main branch github links instead of the relative path. This is not the most elegant solution, but it does fix the links in the readthedocs which has not been working for quite some time.

**Related issues**:

- Fixes #133 


**Instructions to review the pull request**

- Check that CHANGELOG.md has been updated if necessary

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```
-->

<!--
Review online.
-->
