### PR TITLE
Support size = 0 for DeviceMemory constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Fixed the `cu::Module(CUmodule&)` constructor
 - Added `Function::getAttribute` is now const
+- The `cu::DeviceMemory` constructor now works with `size == 0`
 
 ### Fixed
 - Fix compatibility with C++20 and C++23

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -433,7 +433,10 @@ class DeviceMemory : public Wrapper<CUdeviceptr> {
   explicit DeviceMemory(size_t size, CUmemorytype type = CU_MEMORYTYPE_DEVICE,
                         unsigned int flags = 0)
       : _size(size) {
-    if (type == CU_MEMORYTYPE_DEVICE and !flags) {
+    if (size == 0) {
+      _obj = 0;
+      return;
+    } else if (type == CU_MEMORYTYPE_DEVICE && !flags) {
       checkCudaCall(cuMemAlloc(&_obj, size));
     } else if (type == CU_MEMORYTYPE_UNIFIED) {
       checkCudaCall(cuMemAllocManaged(&_obj, size, flags));


### PR DESCRIPTION
**Description**

In some cases, a `cu::DeviceMemory` instance is needed of size zero. The CUDA driver API calls to allocate device memory don't support a zero size argument, so w need a special case in the constructor.

**Related issues**:

- N.A.

**Instructions to review the pull request**

- Check that CHANGELOG.md has been updated if necessary

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```
-->

<!--
Review online.
-->
