### PR TITLE
Fix host memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Fix compatibility with C++20 and C++23
+- Fix `cu::HostMemory` constructor for registered memory
 
 ### Removed
 

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -253,7 +253,7 @@ class HostMemory : public Wrapper<void *> {
   explicit HostMemory(size_t size, unsigned int flags = 0) : _size(size) {
     checkCudaCall(cuMemHostAlloc(&_obj, size, flags));
     manager = std::shared_ptr<void *>(new (void *)(_obj), [](void **ptr) {
-      cuMemFreeHost(*ptr);
+      checkCudaCall(cuMemFreeHost(*ptr));
       delete ptr;
     });
   }
@@ -261,9 +261,10 @@ class HostMemory : public Wrapper<void *> {
   explicit HostMemory(void *ptr, size_t size, unsigned int flags = 0)
       : _size(size) {
     _obj = ptr;
-    checkCudaCall(cuMemHostRegister(&_obj, size, flags));
-    manager = std::shared_ptr<void *>(
-        new (void *)(_obj), [](void **ptr) { cuMemHostUnregister(*ptr); });
+    checkCudaCall(cuMemHostRegister(_obj, size, flags));
+    manager = std::shared_ptr<void *>(new (void *)(_obj), [](void **ptr) {
+      checkCudaCall(cuMemHostUnregister(*ptr));
+    });
   }
 
   template <typename T>


### PR DESCRIPTION
**Description**

The `cu::HostMemory` constructor passed the wrong pointer to `cuMemHostRegister`, which causes `cuMemHostUnregister` to fail. This happened silently, because `checkCudaCall` was missing. This guard was also missing in the other constructor, so added as well.

**Related issues**:

- N.A.

**Instructions to review the pull request**

- Check that CHANGELOG.md has been updated if necessary

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```
-->

<!--
Review online.
-->
