### PR TITLE
Add markdown link checker action

### DIFF
--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -4,8 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-    #- main
-    - add_markdown_link_checker_action
+    - main
   pull_request:
     branches:
     - main

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -27,4 +27,3 @@ jobs:
       with:
         check-modified-files-only: 'yes'
         base-branch: 'main'
-        config-file: '.github/workflows/mlc-config.json'

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -1,0 +1,30 @@
+name: markdown-link-check
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+    #- main
+    - add_markdown_link_checker_action
+  pull_request:
+    branches:
+    - main
+    types:
+    - opened
+    - reopened
+    - synchronize
+    - ready_for_review
+
+jobs:
+
+  markdown-link-check:
+    name: Check markdown links
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@main
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        check-modified-files-only: 'yes'
+        base-branch: 'main'
+        config-file: '.github/workflows/mlc-config.json'

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -24,6 +24,3 @@ jobs:
     steps:
     - uses: actions/checkout@main
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
-      with:
-        check-modified-files-only: 'yes'
-        base-branch: 'main'

--- a/README.dev.md
+++ b/README.dev.md
@@ -144,7 +144,7 @@ To run `clang-tidy` on Codacy for this project or a fork, you will need to defin
 For the `main` branch and pull requests originating from inside this repo, there is no need to create a new token.
 But if it gets revoked, or for forks, follow the steps in the [Codacy API tokens page](https://docs.codacy.com/codacy-api/api-tokens/) for details on how to create one.
 
-After a pull request is created, a Codacy test should appear. Follow the link there or [here](https://app.codacy.com/gh/nlesc-recruit/CUDA-wrappers) for the results.
+After a pull request is created, a Codacy test should appear. Follow the link there or [here](https://app.codacy.com/gh/nlesc-recruit/cudawrappers) for the results.
 
 ### pre-commit hook
 

--- a/README.dev.md
+++ b/README.dev.md
@@ -131,8 +131,7 @@ To run the formatters and linters, you first need to build the project and set u
 In addition, you can install VSCode extensions for many of these linters. Here is a short list:
 
 - [VSCode extension for cmake-format](https://marketplace.visualstudio.com/items?itemName=cheshirekow.cmake-format)
-- [VSCode extension clang-tidy](https://marketplace.visualstudio.com/items?itemName=notskm.clang-tidy)
-- [VSCode extension clang-format](https://marketplace.visualstudio.com/items?itemName=xaver.clang-format)
+- [VSCode extension clang-tidy and clang-format](https://marketplace.visualstudio.com/items?itemName=caphyon.ClangPowerTools)
 
 ### Linters on Codacy
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Research Software Directory](https://img.shields.io/badge/rsd-cudawrappers-00a3e3.svg)](https://www.research-software.nl/software/cudawrappers)
 [![cii badge](https://bestpractices.coreinfrastructure.org/projects/5686/badge)](https://bestpractices.coreinfrastructure.org/projects/5686)
 [![fair-software.eu](https://img.shields.io/badge/fair--software.eu-%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F-green)](https://fair-software.eu)
-[![Codacy Badge](https://app.codacy.com/project/badge/Grade/d38b0338fda24733ab41a64915af8248)](https://www.codacy.com/gh/nlesc-recruit/cudawrappers/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=nlesc-recruit/cudawrappers&amp;utm_campaign=Badge_Grade)
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/d38b0338fda24733ab41a64915af8248)](https://app.codacy.com/gh/nlesc-recruit/cudawrappers/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=nlesc-recruit/cudawrappers&amp;utm_campaign=Badge_Grade)
 [![citation metadata](https://github.com/nlesc-recruit/cudawrappers/actions/workflows/cffconvert.yml/badge.svg)](https://github.com/nlesc-recruit/cudawrappers/actions/workflows/cffconvert.yml)
 [![Documentation Status](https://readthedocs.org/projects/cudawrappers/badge/?version=latest)](https://cudawrappers.readthedocs.io/en/latest/?badge=latest)
 


### PR DESCRIPTION
**Description**

<!-- Description of PR -->

**Related issues**:

- #245 


I added a markdown link check action (for now only applied to this branch, should be changed to main branch before merging). However, it fails at the moment because codacy is not an open website; the link to it can only be opened with a password. Should we simply ignore this link in the check action, or try to fix it with the secrets?

Also, why is codacy not public? 
