### PR TITLE
Use int for return type of CU_POINTER_ATTRIBUTE_IS_MANAGED query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Fix compatibility with C++20 and C++23
 - Fix `cu::HostMemory` constructor for registered memory
+- Fix `cu::DeviceMemory` operator `T *()` for managed memory
 
 ### Removed
 

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -467,7 +467,7 @@ class DeviceMemory : public Wrapper<CUdeviceptr> {
 
   template <typename T>
   operator T *() {
-    bool data;
+    int data;
     checkCudaCall(
         cuPointerGetAttribute(&data, CU_POINTER_ATTRIBUTE_IS_MANAGED, _obj));
     if (data) {


### PR DESCRIPTION
**Description**

A call to `cuPointerGetAttribute` with `CU_POINTER_ATTRIBUTE_IS_MANAGED` argument returns an integer, not a boolean. 

**Related issues**:

- https://github.com/nlesc-recruit/cudawrappers/issues/248

**Instructions to review the pull request**

- Check that CHANGELOG.md has been updated if necessary

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```
-->

<!--
Review online.
-->
