### PR TITLE
Initialize size in Stream::memAllocAsync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fix compatibility with C++20 and C++23
 - Fix `cu::HostMemory` constructor for registered memory
 - Fix `cu::DeviceMemory` operator `T *()` for managed memory
+- Fix `Stream::memAllocAsync` returns `DeviceMemory` with initialized size
 
 ### Removed
 

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -451,7 +451,10 @@ class DeviceMemory : public Wrapper<CUdeviceptr> {
                                            });
   }
 
-  explicit DeviceMemory(CUdeviceptr ptr) : Wrapper(ptr) {}
+  DeviceMemory(CUdeviceptr ptr) = delete;
+
+  explicit DeviceMemory(CUdeviceptr ptr, size_t size)
+      : Wrapper(ptr), _size(size) {}
 
   explicit DeviceMemory(const HostMemory &hostMemory) {
     checkCudaCall(cuMemHostGetDevicePointer(&_obj, hostMemory, 0));
@@ -501,7 +504,7 @@ class Stream : public Wrapper<CUstream> {
   DeviceMemory memAllocAsync(size_t size) {
     CUdeviceptr ptr;
     checkCudaCall(cuMemAllocAsync(&ptr, size, _obj));
-    return DeviceMemory(ptr);
+    return DeviceMemory(ptr, size);
   }
 
   void memFreeAsync(DeviceMemory &devMem) {

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -451,7 +451,7 @@ class DeviceMemory : public Wrapper<CUdeviceptr> {
                                            });
   }
 
-  DeviceMemory(CUdeviceptr ptr) = delete;
+  explicit DeviceMemory(CUdeviceptr ptr) : Wrapper(ptr) {}
 
   explicit DeviceMemory(CUdeviceptr ptr, size_t size)
       : Wrapper(ptr), _size(size) {}

--- a/tests/test_cu.cpp
+++ b/tests/test_cu.cpp
@@ -187,3 +187,18 @@ TEST_CASE("Test zeroing cu::DeviceMemory", "[zero]") {
         cu::DeviceMemory(size, CU_MEMORYTYPE_DEVICE, CU_MEM_ATTACH_HOST));
   }
 }
+
+TEST_CASE("Test cu::Stream", "[stream]") {
+  cu::init();
+  cu::Device device(0);
+  cu::Context context(CU_CTX_SCHED_BLOCKING_SYNC, device);
+  cu::Stream stream;
+
+  SECTION("Test memAllocAsync") {
+    const size_t size = 1024;
+    cu::DeviceMemory mem = stream.memAllocAsync(size);
+    CHECK(mem.size() == size);
+    CHECK_NOTHROW(stream.memFreeAsync(mem));
+    CHECK_NOTHROW(stream.synchronize());
+  }
+}


### PR DESCRIPTION
**Description**

These changes fix the following bug: When calling `Stream::memAllocAsync`, a `DeviceMemory` is returned with it's `_size` member uninitialized. This is problematic when later calling `DeviceMemory::size`.

This is fixed by:
1. Deleting `DeviceMemory(CUdeviceptr)`
2. Adding `DeviceMemory(CUdeviceptr size)` and calling this constructor in `Stream::memAllocAsync`

A new test case was added to verify that the above scenario now works correctly

**Related issues**:

- N.A.

**Instructions to review the pull request**

- Check that CHANGELOG.md has been updated if necessary

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```
-->

<!--
Review online.
-->
