### PR TITLE
Added cu::Function::occupancyMaxActiveBlocksPerMultiprocessor()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Added
+
+- Added `cu::Function::occupancyMaxActiveBlocksPerMultiprocessor()`
+
 ## \[0.7.0\] - 2024-03-08
 
 ### Added

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -394,6 +394,14 @@ class Function : public Wrapper<CUfunction> {
     checkCudaCall(cuFuncSetAttribute(_obj, attribute, value));
   }
 
+  int occupancyMaxActiveBlocksPerMultiprocessor(int blockSize,
+                                                size_t dynamicSMemSize) {
+    int numBlocks;
+    checkCudaCall(cuOccupancyMaxActiveBlocksPerMultiprocessor(
+        &numBlocks, _obj, blockSize, dynamicSMemSize));
+    return numBlocks;
+  }
+
   void setCacheConfig(CUfunc_cache config) {
     checkCudaCall(cuFuncSetCacheConfig(_obj, config));
   }


### PR DESCRIPTION
**Description**

Added cu::Function::occupancyMaxActiveBlocksPerMultiprocessor()

**Related issues**:

- N.A.

**Instructions to review the pull request**

- Check that CHANGELOG.md has been updated if necessary

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```
-->

<!--
Review online.
-->
