### PR TITLE
Let target_embed_source inline local header files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 - Added `cu::Function::occupancyMaxActiveBlocksPerMultiprocessor()`
 
+### Added
+
+- `target_embed_source` will now automatically inline local header files
+
+- Added `cu::Function::occupancyMaxActiveBlocksPerMultiprocessor()`
+
 ## \[0.7.0\] - 2024-03-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,9 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 - Added `cu::Function::occupancyMaxActiveBlocksPerMultiprocessor()`
 
-### Added
+### Changed
 
 - `target_embed_source` will now automatically inline local header files
-
-- Added `cu::Function::occupancyMaxActiveBlocksPerMultiprocessor()`
 
 ## \[0.7.0\] - 2024-03-08
 

--- a/cmake/cudawrappers-helper.cmake
+++ b/cmake/cudawrappers-helper.cmake
@@ -3,13 +3,13 @@
 # '#include "helper.h"` will lead to `helper.h` being inlined.
 function(inline_local_includes input_file output_file)
   file(READ ${input_file} input_file_contents)
-  set(INCLUDE_REGEX "#include[ \t]*\"([^\"]+)\"")
-  string(REGEX MATCHALL ${INCLUDE_REGEX} includes ${input_file_contents})
-  string(REGEX REPLACE ${INCLUDE_REGEX} "" input_file_contents
+  set(include_regex "#include[ \t]*\"([^\"]+)\"")
+  string(REGEX MATCHALL ${include_regex} includes ${input_file_contents})
+  string(REGEX REPLACE ${include_regex} "" input_file_contents
                        "${input_file_contents}"
   )
   foreach(include ${includes})
-    string(REGEX REPLACE ${INCLUDE_REGEX} "\\1" include ${include})
+    string(REGEX REPLACE ${include_regex} "\\1" include ${include})
     file(GLOB_RECURSE INCLUDE_PATH "${CMAKE_SOURCE_DIR}/*/${include}")
     file(READ ${INCLUDE_PATH} include_contents)
     string(APPEND processed_file_contents "${include_contents}\n\n")
@@ -27,9 +27,9 @@ function(target_embed_source target input_file)
   # Strip the path and extension from input_file
   get_filename_component(NAME ${input_file} NAME_WLE)
   # Make a copy of the input file in the binary dir with inlined header files
-  set(INPUT_FILE_INLINED "${CMAKE_BINARY_DIR}/${input_file}")
+  set(input_file_inlined "${CMAKE_BINARY_DIR}/${input_file}")
   inline_local_includes(
-    "${CMAKE_CURRENT_SOURCE_DIR}/${input_file}" ${INPUT_FILE_INLINED}
+    "${CMAKE_CURRENT_SOURCE_DIR}/${input_file}" ${input_file_inlined}
   )
   # Link the input_file into an object file
   add_custom_command(
@@ -37,7 +37,7 @@ function(target_embed_source target input_file)
     COMMAND ld ARGS -r -b binary -A ${CMAKE_SYSTEM_PROCESSOR} -o
             ${CMAKE_CURRENT_BINARY_DIR}/${NAME}.o ${input_file}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    DEPENDS ${input_file} ${INPUT_FILE_INLINED}
+    DEPENDS ${input_file} ${input_file_inlined}
     COMMENT "Creating object file for ${input_file}"
   )
   if(NOT TARGET ${NAME})

--- a/cmake/cudawrappers-helper.cmake
+++ b/cmake/cudawrappers-helper.cmake
@@ -1,3 +1,23 @@
+# Copy the contents of the input file to the output file with all the local
+# includes inlined. Local includes are assumed to have ""'s, e.g. having a line
+# '#include "helper.h"` will lead to `helper.h` being inlined.
+function(inline_local_includes input_file output_file)
+  file(READ ${input_file} input_file_contents)
+  set(INCLUDE_REGEX "#include[ \t]*\"([^\"]+)\"")
+  string(REGEX MATCHALL ${INCLUDE_REGEX} includes ${input_file_contents})
+  string(REGEX REPLACE ${INCLUDE_REGEX} "" input_file_contents
+                       "${input_file_contents}"
+  )
+  foreach(include ${includes})
+    string(REGEX REPLACE ${INCLUDE_REGEX} "\\1" include ${include})
+    file(GLOB_RECURSE INCLUDE_PATH "${CMAKE_SOURCE_DIR}/*/${include}")
+    file(READ ${INCLUDE_PATH} include_contents)
+    string(APPEND processed_file_contents "${include_contents}\n\n")
+  endforeach()
+  string(APPEND processed_file_contents "${input_file_contents}\n")
+  file(WRITE ${output_file} "${processed_file_contents}")
+endfunction()
+
 # Make it possible to embed a source file in a library, and link it to a target.
 # E.g. to link <kernel.cu> into target <example_program>, use
 # target_embed_source(example_program, kernel.cu). This will expose symbols
@@ -6,13 +26,18 @@ function(target_embed_source target input_file)
   include(CMakeDetermineSystem)
   # Strip the path and extension from input_file
   get_filename_component(NAME ${input_file} NAME_WLE)
+  # Make a copy of the input file in the binary dir with inlined header files
+  set(INPUT_FILE_INLINED "${CMAKE_BINARY_DIR}/${input_file}")
+  inline_local_includes(
+    "${CMAKE_CURRENT_SOURCE_DIR}/${input_file}" ${INPUT_FILE_INLINED}
+  )
   # Link the input_file into an object file
   add_custom_command(
     OUTPUT ${NAME}.o
     COMMAND ld ARGS -r -b binary -A ${CMAKE_SYSTEM_PROCESSOR} -o
             ${CMAKE_CURRENT_BINARY_DIR}/${NAME}.o ${input_file}
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    DEPENDS ${input_file}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    DEPENDS ${input_file} ${INPUT_FILE_INLINED}
     COMMENT "Creating object file for ${input_file}"
   )
   if(NOT TARGET ${NAME})


### PR DESCRIPTION
**Description**

`target_embed_source` will now look for includes of local header files and inline these before embedding the source file.

**Related issues**:

-  https://github.com/nlesc-recruit/cudawrappers/issues/262

**Instructions to review the pull request**

- Check that CHANGELOG.md has been updated if necessary

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```
-->

<!--
Review online.
-->
