### PR TITLE
Fix target_embed_source when input file is a relative path

### DIFF
--- a/cmake/cudawrappers-helper.cmake
+++ b/cmake/cudawrappers-helper.cmake
@@ -31,10 +31,10 @@ function(target_embed_source target input_file)
   # Get absolute path for input file
   get_filename_component(input_file_absolute "${input_file}" ABSOLUTE)
   message("target_embed_source input_file_absolute: " ${input_file_absolute})
-  # Get absolute path for input file
-  # Make a copy of the input file in the binary dir with inlined header files
-  string(REPLACE "${CMAKE_SOURCE_DIR}" "${CMAKE_BINARY_DIR}" input_file_inlined
-                 ${input_file_absolute}
+  # Get absolute path for input file Make a copy of the input file in the binary
+  # dir with inlined header files
+  string(REPLACE "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_BINARY_DIR}"
+                 input_file_inlined ${input_file_absolute}
   )
   message("target_embed_source input_file_inlined: " ${input_file_inlined})
   inline_local_includes("${input_file_absolute}" ${input_file_inlined})

--- a/cmake/cudawrappers-helper.cmake
+++ b/cmake/cudawrappers-helper.cmake
@@ -23,15 +23,20 @@ endfunction()
 # target_embed_source(example_program, kernel.cu). This will expose symbols
 # _binary_kernel_cu_start and _binary_kernel_cu_end.
 function(target_embed_source target input_file)
+  message("target_embed_source input_file: " ${input_file})
   include(CMakeDetermineSystem)
   # Strip the path and extension from input_file
   get_filename_component(NAME ${input_file} NAME_WLE)
+  message("target_embed_source NAME: " ${NAME})
   # Get absolute path for input file
   get_filename_component(input_file_absolute "${input_file}" ABSOLUTE)
+  message("target_embed_source input_file_absolute: " ${input_file_absolute})
+  # Get absolute path for input file
   # Make a copy of the input file in the binary dir with inlined header files
   string(REPLACE "${CMAKE_SOURCE_DIR}" "${CMAKE_BINARY_DIR}" input_file_inlined
                  ${input_file_absolute}
   )
+  message("target_embed_source input_file_inlined: " ${input_file_inlined})
   inline_local_includes("${input_file_absolute}" ${input_file_inlined})
   # Link the input_file into an object file
   add_custom_command(

--- a/cmake/cudawrappers-helper.cmake
+++ b/cmake/cudawrappers-helper.cmake
@@ -29,7 +29,9 @@ function(target_embed_source target input_file)
   # Get absolute path for input file
   get_filename_component(input_file_absolute "${input_file}" ABSOLUTE)
   # Make a copy of the input file in the binary dir with inlined header files
-  set(input_file_inlined "${CMAKE_BINARY_DIR}/${input_file}")
+  string(REPLACE "${CMAKE_SOURCE_DIR}" "${CMAKE_BINARY_DIR}" input_file_inlined
+                 ${input_file_absolute}
+  )
   inline_local_includes("${input_file_absolute}" ${input_file_inlined})
   # Link the input_file into an object file
   add_custom_command(

--- a/cmake/cudawrappers-helper.cmake
+++ b/cmake/cudawrappers-helper.cmake
@@ -26,11 +26,11 @@ function(target_embed_source target input_file)
   include(CMakeDetermineSystem)
   # Strip the path and extension from input_file
   get_filename_component(NAME ${input_file} NAME_WLE)
+  # Get absolute path for input file
+  get_filename_component(input_file_absolute "${input_file}" ABSOLUTE)
   # Make a copy of the input file in the binary dir with inlined header files
   set(input_file_inlined "${CMAKE_BINARY_DIR}/${input_file}")
-  inline_local_includes(
-    "${CMAKE_CURRENT_SOURCE_DIR}/${input_file}" ${input_file_inlined}
-  )
+  inline_local_includes("${input_file_absolute}" ${input_file_inlined})
   # Link the input_file into an object file
   add_custom_command(
     OUTPUT ${NAME}.o

--- a/cmake/cudawrappers-helper.cmake
+++ b/cmake/cudawrappers-helper.cmake
@@ -23,20 +23,16 @@ endfunction()
 # target_embed_source(example_program, kernel.cu). This will expose symbols
 # _binary_kernel_cu_start and _binary_kernel_cu_end.
 function(target_embed_source target input_file)
-  message("target_embed_source input_file: " ${input_file})
   include(CMakeDetermineSystem)
   # Strip the path and extension from input_file
   get_filename_component(NAME ${input_file} NAME_WLE)
-  message("target_embed_source NAME: " ${NAME})
   # Get absolute path for input file
   get_filename_component(input_file_absolute "${input_file}" ABSOLUTE)
-  message("target_embed_source input_file_absolute: " ${input_file_absolute})
   # Get absolute path for input file Make a copy of the input file in the binary
   # dir with inlined header files
   string(REPLACE "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_BINARY_DIR}"
                  input_file_inlined ${input_file_absolute}
   )
-  message("target_embed_source input_file_inlined: " ${input_file_inlined})
   inline_local_includes("${input_file_absolute}" ${input_file_inlined})
   # Link the input_file into an object file
   add_custom_command(


### PR DESCRIPTION
**Description**

In some cases, `target_embed_source` fails when the input argument is a relative path that contains `..` . This is fixed by using `ABSOLUTE` instead of `WLE`. This also simplifies the call to `inline_local_includes`.

**Related issues**:

- N.A.

**Instructions to review the pull request**

- Check that CHANGELOG.md has been updated if necessary

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```
-->

<!--
Review online.
-->
