### PR TITLE
Removed deprecated cu::Context::setSharedMemConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 - `target_embed_source` will now automatically inline local header files
 
+### Removed
+
+- Removed deprecated `cu::Context::setSharedMemConfig`
+
 ## \[0.7.0\] - 2024-03-08
 
 ### Added

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -194,10 +194,6 @@ class Context : public Wrapper<CUcontext> {
     return Context(context);
   }
 
-  void setSharedMemConfig(CUsharedconfig config) {
-    checkCudaCall(cuCtxSetSharedMemConfig(config));
-  }
-
   static Device getDevice() {
     CUdevice device;
     checkCudaCall(cuCtxGetDevice(&device));


### PR DESCRIPTION
**Description**

Cudawrappers gives a lot of warning regarding the use of a deprecated API:
```
__CUDA_DEPRECATED CUresult CUDAAPI cuCtxSetSharedMemConfig(CUsharedconfig config);
```
This is resolved by removing the offending function call.

**Related issues**:

- N.A.

**Instructions to review the pull request**

- Check that CHANGELOG.md has been updated if necessary

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```
-->

<!--
Review online.
-->
