### PR TITLE
Extend api

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           cuda: ${{ env.cuda-version }}
           method: "network"
-          sub-packages: '["nvcc", "nvrtc-dev", "nvtx"]'
+          sub-packages: '["nvcc", "nvml", "nvrtc-dev", "nvtx"]'
           non-cuda-sub-packages: '["libcufft-dev"]'
           linux-local-args: '["--toolkit"]'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           cuda: ${{ env.cuda-version }}
           method: "network"
-          sub-packages: '["nvcc", "nvml", "nvrtc-dev", "nvtx"]'
+          sub-packages: '["nvcc", "nvml-dev", "nvrtc-dev", "nvtx"]'
           non-cuda-sub-packages: '["libcufft-dev"]'
           linux-local-args: '["--toolkit"]'
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           cuda: ${{ env.cuda-version }}
           method: "network"
-          sub-packages: '["nvcc", "nvml-dev" "nvrtc-dev", "nvtx"]'
+          sub-packages: '["nvcc", "nvml-dev", "nvrtc-dev", "nvtx"]'
           non-cuda-sub-packages: '["libcufft-dev"]'
           linux-local-args: '["--toolkit"]'
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           cuda: ${{ env.cuda-version }}
           method: "network"
-          sub-packages: '["nvcc", "nvrtc-dev", "nvtx"]'
+          sub-packages: '["nvcc", "nvml-dev" "nvrtc-dev", "nvtx"]'
           non-cuda-sub-packages: '["libcufft-dev"]'
           linux-local-args: '["--toolkit"]'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Added `cu::Function::occupancyMaxActiveBlocksPerMultiprocessor()`
+- Added `cu::Device::getUUID()`
+- Added initial cudawrappers::nvml target
 
 ### Changed
 

--- a/cmake/cudawrappers-targets.cmake
+++ b/cmake/cudawrappers-targets.cmake
@@ -4,9 +4,10 @@ get_filename_component(
 )
 
 # Define all the individual components that cudawrappers provides
-set(CUDAWRAPPERS_COMPONENTS cu cufft nvrtc nvtx)
+set(CUDAWRAPPERS_COMPONENTS cu cufft nvml nvrtc nvtx)
 set(LINK_cu CUDA::cuda_driver)
 set(LINK_cufft CUDA::cuda_driver CUDA::cufft)
+set(LINK_nvml CUDA::cuda_driver CUDA::nvml)
 set(LINK_nvrtc CUDA::cuda_driver CUDA::nvrtc)
 set(LINK_nvtx CUDA::nvToolsExt)
 

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -118,6 +118,29 @@ class Device : public Wrapper<CUdevice> {
     return {name.data()};
   }
 
+  std::string getUuid() const {
+    CUuuid uuid;
+    checkCudaCall(cuDeviceGetUuid(&uuid, _obj));
+
+    // Convert a CUuuid to CUDA's string representation.
+    // The CUuuid contains an array of 16 bytes, the UUID has
+    // the form 'GPU-XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXX', with every
+    // X being an alphanumeric character.
+    std::stringstream result;
+    result << "GPU";
+
+    for (int i = 0; i < 16; ++i) {
+      if (i == 0 || i == 4 || i == 6 || i == 8 || i == 10) {
+        result << "-";
+      }
+      result << std::hex << std::setfill('0') << std::setw(2)
+             << static_cast<unsigned>(
+                    static_cast<unsigned char>(uuid.bytes[i]));
+    }
+
+    return result.str();
+  }
+
   size_t totalMem() const {
     size_t size{};
     checkCudaCall(cuDeviceTotalMem(&size, _obj));

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -4,6 +4,7 @@
 #include <array>
 #include <cstddef>
 #include <exception>
+#include <iomanip>
 #include <map>
 #include <memory>
 #include <stdexcept>

--- a/include/cudawrappers/nvml.hpp
+++ b/include/cudawrappers/nvml.hpp
@@ -1,0 +1,50 @@
+#if !defined NVML_H
+#define NVML_H
+
+#include <nvml.h>
+
+#include <exception>
+
+#include <cudawrappers/cu.hpp>
+
+namespace nvml {
+class Error : public std::exception {
+ public:
+  explicit Error(nvmlReturn_t result) : _result(result) {}
+
+  const char* what() const noexcept { return nvmlErrorString(_result); }
+
+  operator nvmlReturn_t() const { return _result; }
+
+ private:
+  nvmlReturn_t _result;
+};
+
+inline void checkNvmlCall(nvmlReturn_t result) {
+  if (result != NVML_SUCCESS) throw Error(result);
+}
+
+class Device {
+ public:
+  Device(int index) {
+    checkNvmlCall(nvmlInit());
+    checkNvmlCall(nvmlDeviceGetHandleByIndex(index, &device_));
+  }
+
+  Device(cu::Device& device) {
+    const std::string uuid = device.getUuid();
+    nvmlDeviceGetHandleByUUID(uuid.c_str(), &device_);
+  }
+
+  ~Device() { checkNvmlCall(nvmlShutdown()); }
+
+  void getFieldValues(int valuesCount, nvmlFieldValue_t* values) {
+    checkNvmlCall(nvmlDeviceGetFieldValues(device_, valuesCount, values));
+  }
+
+ private:
+  nvmlDevice_t device_;
+};
+}  // namespace nvml
+
+#endif

--- a/include/cudawrappers/nvml.hpp
+++ b/include/cudawrappers/nvml.hpp
@@ -32,6 +32,7 @@ class Device {
   }
 
   Device(cu::Device& device) {
+    checkNvmlCall(nvmlInit());
     const std::string uuid = device.getUuid();
     nvmlDeviceGetHandleByUUID(uuid.c_str(), &device_);
   }

--- a/include/cudawrappers/nvml.hpp
+++ b/include/cudawrappers/nvml.hpp
@@ -24,20 +24,23 @@ inline void checkNvmlCall(nvmlReturn_t result) {
   if (result != NVML_SUCCESS) throw Error(result);
 }
 
+class Context {
+ public:
+  Context() { checkNvmlCall(nvmlInit()); }
+
+  ~Context() { checkNvmlCall(nvmlShutdown()); }
+};
+
 class Device {
  public:
-  Device(int index) {
-    checkNvmlCall(nvmlInit());
+  Device(Context& context, int index) {
     checkNvmlCall(nvmlDeviceGetHandleByIndex(index, &device_));
   }
 
-  Device(cu::Device& device) {
-    checkNvmlCall(nvmlInit());
+  Device(Context& context, cu::Device& device) {
     const std::string uuid = device.getUuid();
     nvmlDeviceGetHandleByUUID(uuid.c_str(), &device_);
   }
-
-  ~Device() { checkNvmlCall(nvmlShutdown()); }
 
   void getFieldValues(int valuesCount, nvmlFieldValue_t* values) {
     checkNvmlCall(nvmlDeviceGetFieldValues(device_, valuesCount, values));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,7 +12,7 @@ FetchContent_MakeAvailable(Catch2)
 list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/contrib)
 include(Catch)
 
-set(COMPONENTS cu nvrtc cufft vector_add)
+set(COMPONENTS cu nvml nvrtc cufft vector_add)
 
 foreach(component ${COMPONENTS})
   add_executable(test_${component} test_${component}.cpp)
@@ -25,6 +25,8 @@ endforeach()
 set(LINK_LIBRARIES Catch2::Catch2 cudawrappers::cu)
 
 target_link_libraries(test_cu PUBLIC ${LINK_LIBRARIES})
+
+target_link_libraries(test_nvml PUBLIC ${LINK_LIBRARIES} cudawrappers::nvml)
 
 target_link_libraries(test_nvrtc PUBLIC ${LINK_LIBRARIES} cudawrappers::nvrtc)
 

--- a/tests/test_nvml.cpp
+++ b/tests/test_nvml.cpp
@@ -1,0 +1,21 @@
+#include <string>
+#include <vector>
+
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+#include <cudawrappers/cu.hpp>
+#include <cudawrappers/nvml.hpp>
+
+TEST_CASE("Test nvml::Context", "[context]") { nvml::Context context; }
+
+TEST_CASE("Test nvml::Device with device number", "[device]") {
+  nvml::Context context;
+  nvml::Device device(context, 0);
+}
+
+TEST_CASE("Test nvml::Device with device", "[device]") {
+  cu::init();
+  cu::Device cu_device(0);
+  nvml::Context nvml_context;
+  nvml::Device nvml_device(nvml_context, cu_device);
+}


### PR DESCRIPTION
**Description**

Extend the API so that cudawrappers can also be used in [PMT](https://git.astron.nl/RD/pmt):

- Added `cu::Device::getUUID()`
- Added `cudawrappers::nvml` target with only the functionality that PMT needs

**Related issues**:

- N.A.

**Instructions to review the pull request**

- Check that CHANGELOG.md has been updated if necessary

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```
-->

<!--
Review online.
-->
