### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           cuda: ${{ env.cuda-version }}
           method: "network"
-          sub-packages: '["nvcc", "nvml-dev", "nvrtc-dev", "nvtx"]'
+          sub-packages: '["runtime", "nvcc", "nvml-dev", "nvrtc-dev", "nvtx"]'
           non-cuda-sub-packages: '["libcufft-dev"]'
           linux-local-args: '["--toolkit"]'
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: cppcheck
         args:
           - '--project=build/compile_commands.json'
-          - '--suppress=*:build/*'
+          - '--suppress=*:*/build/*'
           - '--suppress=unusedFunction:*/*'
           - '--suppress=unreadVariable:tests/*'
           - '--suppress=missingIncludeSystem'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: cppcheck
         args:
           - '--project=build/compile_commands.json'
-          - '--suppress=*:*/build/*'
+          - '--suppress=*:build/*'
           - '--suppress=unusedFunction:*/*'
           - '--suppress=unreadVariable:tests/*'
           - '--suppress=missingIncludeSystem'

--- a/tests/test_nvrtc.cpp
+++ b/tests/test_nvrtc.cpp
@@ -28,12 +28,12 @@ TEST_CASE("Test nvrtc::Program", "[program]") {
   }
 }
 
-extern const char _binary_kernels_vector_add_kernel_cu_start,
-    _binary_kernels_vector_add_kernel_cu_end;
+extern const char _binary_tests_kernels_vector_add_kernel_cu_start,
+    _binary_tests_kernels_vector_add_kernel_cu_end;
 
 TEST_CASE("Test nvrtc::Program embedded source", "[program]") {
-  const std::string kernel(&_binary_kernels_vector_add_kernel_cu_start,
-                           &_binary_kernels_vector_add_kernel_cu_end);
+  const std::string kernel(&_binary_tests_kernels_vector_add_kernel_cu_start,
+                           &_binary_tests_kernels_vector_add_kernel_cu_end);
   nvrtc::Program program(kernel, "vector_add_kernel.cu");
 
   SECTION("Test Program.compile") {


### PR DESCRIPTION
**Description**

The CI was failing due to the `runtime` subpackage not being installed: `libcuda.so.1` was not found. Also, after changing the `target_embed_source` `test_nvrtc` needed an update for its symbols (it now also takes the `tests` subdirectory into account).

~~Finally, even though this check is currently disabled in the CI, the `build` directory is not properly ignored by `cppcheck`.~~ This change actually caused the CI to fail! It has been reverted again.

**Related issues**:

- N.A.