### PR TITLE
Add nvrtc::findIncludePath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Added `cu::Function::occupancyMaxActiveBlocksPerMultiprocessor()`
 - Added `cu::Device::getUUID()`
 - Added initial cudawrappers::nvml target
+- Added `nvrtc::findIncludePath()`
 
 ### Changed
 

--- a/tests/test_nvrtc.cpp
+++ b/tests/test_nvrtc.cpp
@@ -46,3 +46,8 @@ TEST_CASE("Test nvrtc::Program embedded source", "[program]") {
     CHECK(ptx.size() > 0);
   }
 }
+
+TEST_CASE("Test nvrtc::findIncludePath", "[helper]") {
+  const std::string path = nvrtc::findIncludePath();
+  CHECK(path.find("include") != std::string::npos);
+}


### PR DESCRIPTION
**Description**

Add `nvrtc::findIncludePath` based on [this](https://git.astron.nl/RD/tensor-core-correlator/-/blob/master/libtcc/Correlator.cc?ref_type=heads#L14) code. Since cudawrappers uses C++17, the `std::filesystem::exists` C++17 function was replaced by a C alternative. The new helper function is also tested by `test_nvrtc`.

**Related issues**:

- N.A.

**Instructions to review the pull request**

- Check that CHANGELOG.md has been updated if necessary

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```
-->

<!--
Review online.
-->
