### PR TITLE
Make nvrtc::findIncludePath inline

### DIFF
--- a/include/cudawrappers/nvrtc.hpp
+++ b/include/cudawrappers/nvrtc.hpp
@@ -32,7 +32,7 @@ inline void checkNvrtcCall(nvrtcResult result) {
   if (result != NVRTC_SUCCESS) throw Error(result);
 }
 
-std::string findIncludePath() {
+inline std::string findIncludePath() {
   std::string path;
 
   if (dl_iterate_phdr(


### PR DESCRIPTION
**Description**

This fixes a problem where `findIncludePath` is defined multiple times.

**Related issues**:

- N.A.

