### PR TITLE
Add nvml::Device::getClock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Added `cu::Device::getUUID()`
 - Added initial cudawrappers::nvml target
 - Added `nvrtc::findIncludePath()`
+- Added `nvml::Device::getClock`
 
 ### Changed
 

--- a/include/cudawrappers/nvml.hpp
+++ b/include/cudawrappers/nvml.hpp
@@ -46,6 +46,12 @@ class Device {
     checkNvmlCall(nvmlDeviceGetFieldValues(device_, valuesCount, values));
   }
 
+  unsigned int getClock(nvmlClockType_t clockType, nvmlClockId_t clockId) {
+    unsigned int clockMhz;
+    checkNvmlCall(nvmlDeviceGetClock(device_, clockType, clockId, &clockMhz));
+    return clockMhz;
+  }
+
  private:
   nvmlDevice_t device_;
 };

--- a/tests/test_nvml.cpp
+++ b/tests/test_nvml.cpp
@@ -13,6 +13,14 @@ TEST_CASE("Test nvml::Device with device number", "[device]") {
   nvml::Device device(context, 0);
 }
 
+TEST_CASE("Test nvml::Device::getClock", "[device]") {
+  nvml::Context context;
+  nvml::Device device(context, 0);
+  const unsigned int clockMHz =
+      device.getClock(NVML_CLOCK_GRAPHICS, NVML_CLOCK_ID_CURRENT);
+  REQUIRE(clockMHz > 0);
+}
+
 TEST_CASE("Test nvml::Device with device", "[device]") {
   cu::init();
   cu::Device cu_device(0);


### PR DESCRIPTION
**Description**

Add the `Device::getClock` function to the NVMML interface, wrapping `nvmlDeviceGetClock`.

**Related issues**:

- N.A.

**Instructions to review the pull request**

- Check that CHANGELOG.md has been updated if necessary

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```
-->

<!--
Review online.
-->
