### PR TITLE
Prepare release 0.8.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.6.0
+current_version = 0.8.0
 
 [bumpversion:file:docs/conf.py]
 search = release = '{current_version}'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased
+## \[0.8.0\] - 2024-07-05
 
 ### Added
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -81,4 +81,4 @@ keywords:
   - accelerators
 license: Apache-2.0
 date-released: 2022-03-08
-version: "0.6.0"
+version: "0.8.0"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 project(
   cudawrappers
   DESCRIPTION "C++ Wrappers for the CUDA Driver API"
-  VERSION 0.6.0
+  VERSION 0.8.0
   HOMEPAGE_URL https://github.com/nlesc-recruit/cudawrappers
   LANGUAGES CXX
 )

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = '2022, cudawrappers developers'
 author = 'cudawrappers developers'
 
 # The full version, including alpha/beta/rc tags
-release = '0.6.0'
+release = '0.8.0'
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
**Description**

Update `CHANGELOG.md` and version numbers for the upcoming release of version 0.8.0.

**Related issues**:

- N.A.

**Instructions to review the pull request**

- Check that CHANGELOG.md has been updated if necessary

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```
-->

<!--
Review online.
-->
