### PR TITLE
Fix inline local includes edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- `inline_local_includes` is now more robust: it properly handles commented 
+- `inline_local_includes` is now more robust: it properly handles commented
   includes and respects the location of an include in the original source file
 
 ## \[0.8.0\] - 2024-07-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Changed
+
+- `inline_local_includes` is now more robust: it properly handles commented 
+  includes and respects the location of an include in the original source file
+
 ## \[0.8.0\] - 2024-07-05
 
 ### Added

--- a/cmake/cudawrappers-helper.cmake
+++ b/cmake/cudawrappers-helper.cmake
@@ -7,8 +7,10 @@ function(inline_local_includes input_file output_file)
   string(REGEX MATCHALL ${include_regex} includes ${input_file_contents})
   set(include_files "")
   foreach(include ${includes})
-    string(REGEX REPLACE ${include_regex} "\\3" include_name ${include}) # e.g. 'helper.h'
-    string(REGEX REPLACE ${include_regex} "\\2" include_line ${include}) # e.g.  '#include <helper.h>'
+    string(REGEX REPLACE ${include_regex} "\\3" include_name ${include}
+    )# e.g. 'helper.h'
+    string(REGEX REPLACE ${include_regex} "\\2" include_line ${include}
+    )# e.g.  '#include <helper.h>'
     file(GLOB_RECURSE INCLUDE_PATHS "${PROJECT_SOURCE_DIR}/*/${include_name}")
     if(NOT INCLUDE_PATHS STREQUAL "")
       list(SORT INCLUDE_PATHS ORDER DESCENDING)

--- a/cmake/cudawrappers-helper.cmake
+++ b/cmake/cudawrappers-helper.cmake
@@ -7,7 +7,7 @@ function(inline_local_includes input_file output_file)
   string(REGEX MATCHALL ${include_regex} includes ${input_file_contents})
   set(include_files "")
   foreach(include ${includes})
-    string(REGEX REPLACE ${include_regex} "\\3" include_name ${include})
+    string(REGEX REPLACE ${include_regex} "\\3" include_name ${include}) # e.g. 'helper.h'
     string(REGEX REPLACE ${include_regex} "\\2" include_line ${include})
     file(GLOB_RECURSE INCLUDE_PATHS "${PROJECT_SOURCE_DIR}/*/${include_name}")
     if(NOT INCLUDE_PATHS STREQUAL "")

--- a/cmake/cudawrappers-helper.cmake
+++ b/cmake/cudawrappers-helper.cmake
@@ -3,25 +3,24 @@
 # '#include "helper.h"` will lead to `helper.h` being inlined.
 function(inline_local_includes input_file output_file)
   file(READ ${input_file} input_file_contents)
-  set(include_regex "#include[ \t]*\"([^\"]+)\"")
+  set(include_regex "(^|\r?\n)(#include[ \t]*\"([^\"]+)\")")
   string(REGEX MATCHALL ${include_regex} includes ${input_file_contents})
-  string(REGEX REPLACE ${include_regex} "" input_file_contents
-                       "${input_file_contents}"
-  )
   set(include_files "")
   foreach(include ${includes})
-    string(REGEX REPLACE ${include_regex} "\\1" include ${include})
-    file(GLOB_RECURSE INCLUDE_PATHS "${PROJECT_SOURCE_DIR}/*/${include}")
+    string(REGEX REPLACE ${include_regex} "\\3" include_name ${include})
+    string(REGEX REPLACE ${include_regex} "\\2" include_line ${include})
+    file(GLOB_RECURSE INCLUDE_PATHS "${PROJECT_SOURCE_DIR}/*/${include_name}")
     if(NOT INCLUDE_PATHS STREQUAL "")
       list(SORT INCLUDE_PATHS ORDER DESCENDING)
       list(GET INCLUDE_PATHS 0 include_PATH)
       list(APPEND include_files ${include_PATH})
       file(READ ${include_PATH} include_contents)
-      string(APPEND processed_file_contents "${include_contents}\n\n")
+      string(REPLACE "${include_line}" "${include_contents}"
+                     input_file_contents "${input_file_contents}"
+      )
     endif()
   endforeach()
-  string(APPEND processed_file_contents "${input_file_contents}\n")
-  file(WRITE ${output_file} "${processed_file_contents}")
+  file(WRITE ${output_file} "${input_file_contents}")
   set(include_files
       ${include_files}
       PARENT_SCOPE

--- a/cmake/cudawrappers-helper.cmake
+++ b/cmake/cudawrappers-helper.cmake
@@ -8,7 +8,7 @@ function(inline_local_includes input_file output_file)
   set(include_files "")
   foreach(include ${includes})
     string(REGEX REPLACE ${include_regex} "\\3" include_name ${include}) # e.g. 'helper.h'
-    string(REGEX REPLACE ${include_regex} "\\2" include_line ${include})
+    string(REGEX REPLACE ${include_regex} "\\2" include_line ${include}) # e.g.  '#include <helper.h>'
     file(GLOB_RECURSE INCLUDE_PATHS "${PROJECT_SOURCE_DIR}/*/${include_name}")
     if(NOT INCLUDE_PATHS STREQUAL "")
       list(SORT INCLUDE_PATHS ORDER DESCENDING)

--- a/cmake/cudawrappers-helper.cmake
+++ b/cmake/cudawrappers-helper.cmake
@@ -7,10 +7,10 @@ function(inline_local_includes input_file output_file)
   string(REGEX MATCHALL ${include_regex} includes ${input_file_contents})
   set(include_files "")
   foreach(include ${includes})
-    string(REGEX REPLACE ${include_regex} "\\3" include_name ${include}
-    )# e.g. 'helper.h'
-    string(REGEX REPLACE ${include_regex} "\\2" include_line ${include}
-    )# e.g.  '#include <helper.h>'
+    # Get the name of the file to include, e.g. 'helper.h'
+    string(REGEX REPLACE ${include_regex} "\\3" include_name ${include})
+    # Get the complete line of the include, e.g.  '#include <helper.h>'
+    string(REGEX REPLACE ${include_regex} "\\2" include_line ${include})
     file(GLOB_RECURSE INCLUDE_PATHS "${PROJECT_SOURCE_DIR}/*/${include_name}")
     if(NOT INCLUDE_PATHS STREQUAL "")
       list(SORT INCLUDE_PATHS ORDER DESCENDING)


### PR DESCRIPTION


**Description**

- #include must be the start of a line
- the inlined included is placed in the same line as the original #include

**Related issues**:

This fixes cases such as
```
#ifdef __HIP__
//include "disabled_header.h"
#include "some_header.h"
#endif
```
Before this PR, the commented out include would be inlined, and both inlined headers would be placed at the top of the file.

**Instructions to review the pull request**

- Check that CHANGELOG.md has been updated if necessary