### PR TITLE
Add option to create slice of device memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 - Added compatibility with HIP
 - Added `cu::Device::getArch()`
-- Added `cu::DeviceMemory` constructor to create non-owning slice of 
-  another `cu::DeviceMemory` object
+- Added `cu::DeviceMemory` constructor to create non-owning slice of another
+  `cu::DeviceMemory` object
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 - Added compatibility with HIP
 - Added `cu::Device::getArch()`
+- Added `cu::DeviceMemory` constructor to create non-owning slice of 
+  another `cu::DeviceMemory` object
 
 ### Changed
 

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -574,6 +574,14 @@ class DeviceMemory : public Wrapper<CUdeviceptr> {
     checkCudaCall(cuMemHostGetDevicePointer(&_obj, hostMemory, 0));
   }
 
+  explicit DeviceMemory(const DeviceMemory &other, size_t offset, size_t size)
+      : _size(size) {
+    if (size + offset > other.size()) {
+      throw Error(CUDA_ERROR_INVALID_VALUE);
+    }
+    _obj = reinterpret_cast<CUdeviceptr>(reinterpret_cast<char *>(other._obj) + offset);
+  }
+
   void zero(size_t size) { checkCudaCall(cuMemsetD8(_obj, 0, size)); }
 
   const void *parameter()

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -579,7 +579,8 @@ class DeviceMemory : public Wrapper<CUdeviceptr> {
     if (size + offset > other.size()) {
       throw Error(CUDA_ERROR_INVALID_VALUE);
     }
-    _obj = reinterpret_cast<CUdeviceptr>(reinterpret_cast<char *>(other._obj) + offset);
+    _obj = reinterpret_cast<CUdeviceptr>(reinterpret_cast<char *>(other._obj) +
+                                         offset);
   }
 
   void zero(size_t size) { checkCudaCall(cuMemsetD8(_obj, 0, size)); }

--- a/tests/test_cu.cpp
+++ b/tests/test_cu.cpp
@@ -187,6 +187,22 @@ TEST_CASE("Test zeroing cu::DeviceMemory", "[zero]") {
     CHECK_THROWS(
         cu::DeviceMemory(size, CU_MEMORYTYPE_DEVICE, CU_MEM_ATTACH_HOST));
   }
+
+  SECTION("Test cu::DeviceMemory offset") {
+    const size_t size = 1024;
+    const size_t offset = 512;
+    const size_t slice_size = 512;
+    cu::DeviceMemory mem(size);
+    CHECK_NOTHROW(cu::DeviceMemory(mem, offset, slice_size));
+  }
+
+  SECTION("Test cu::DeviceMemory invalid offset") {
+    const size_t size = 1024;
+    const size_t offset = 512;
+    const size_t slice_size = 1024;
+    cu::DeviceMemory mem(size);
+    CHECK_THROWS(cu::DeviceMemory(mem, offset, slice_size));
+  }
 }
 
 TEST_CASE("Test cu::Stream", "[stream]") {


### PR DESCRIPTION
**Description**

Added a `DeviceMemory` constructor that creates a slice from another `DeviceMemory` object, without taking ownership.
Tests for both correct and out-of-bounds usage were added.

**Related issues**:

#291 


