### PR TITLE
Update C++ to C++14 and Catch2 to 3.6.0

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -81,7 +81,7 @@ IfMacros:
   - KJ_IF_MAYBE
 IncludeBlocks:   Regroup
 IncludeCategories:
-  - Regex:           '^<catch2/catch.hpp|cuda.h|cuda_runtime_api.h|nvrtc.h|cudawrappers/.*\.hpp>'
+  - Regex:           '^<cuda.h|cuda_runtime_api.h|nvrtc.h|cudawrappers/.*\.hpp>'
     Priority:        3
     SortPriority:    0
     CaseSensitive:   false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - `cu::Context::{getCurrent, popCurrent, getDevice}` are no longer static
 - `inline_local_includes` is now more robust: it properly handles commented
   includes and respects the location of an include in the original source file
+- Upgrade C++ standard to C++14
+- Upgrade Catch2 to version v3.6.0
 
 ## \[0.8.0\] - 2024-07-05
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ project(
 
 include(GNUInstallDirs)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_CXX_EXTENSIONS False)
 set(CMAKE_BUILD_TYPE Release)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,11 +1,9 @@
 include(FetchContent)
 
-# We use Catch2 v2.x because it is the last version that supports C++11, see
-# https://github.com/catchorg/Catch2.
 FetchContent_Declare(
   Catch2
   GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-  GIT_TAG v2.13.9
+  GIT_TAG v3.6.0
 )
 
 FetchContent_MakeAvailable(Catch2)
@@ -28,7 +26,7 @@ foreach(component ${COMPONENTS})
   catch_discover_tests(test_${component})
 endforeach()
 
-set(LINK_LIBRARIES Catch2::Catch2 cudawrappers::cu)
+set(LINK_LIBRARIES Catch2::Catch2WithMain cudawrappers::cu)
 
 target_link_libraries(test_cu PUBLIC ${LINK_LIBRARIES})
 

--- a/tests/test_cu.cpp
+++ b/tests/test_cu.cpp
@@ -4,7 +4,7 @@
 #include <string>
 
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <cudawrappers/cu.hpp>
 
 TEST_CASE("Test cu::Device", "[device]") {

--- a/tests/test_cu.cpp
+++ b/tests/test_cu.cpp
@@ -1,9 +1,9 @@
 #include <array>
+#include <catch2/catch_test_macros.hpp>
 #include <cstring>
 #include <iostream>
 #include <string>
 
-#include <catch2/catch_test_macros.hpp>
 #include <cudawrappers/cu.hpp>
 
 TEST_CASE("Test cu::Device", "[device]") {

--- a/tests/test_cu.cpp
+++ b/tests/test_cu.cpp
@@ -3,7 +3,6 @@
 #include <iostream>
 #include <string>
 
-#define CATCH_CONFIG_MAIN
 #include <catch2/catch_test_macros.hpp>
 #include <cudawrappers/cu.hpp>
 

--- a/tests/test_cufft.cpp
+++ b/tests/test_cufft.cpp
@@ -2,7 +2,8 @@
 #include <iostream>
 
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <cudawrappers/cufft.hpp>
 
 #define FP16_EPSILON 1e-3f

--- a/tests/test_cufft.cpp
+++ b/tests/test_cufft.cpp
@@ -1,8 +1,8 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <fstream>
 #include <iostream>
 
-#include <catch2/catch_test_macros.hpp>
-#include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <cudawrappers/cufft.hpp>
 
 #define FP16_EPSILON 1e-3f

--- a/tests/test_cufft.cpp
+++ b/tests/test_cufft.cpp
@@ -1,7 +1,6 @@
 #include <fstream>
 #include <iostream>
 
-#define CATCH_CONFIG_MAIN
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <cudawrappers/cufft.hpp>

--- a/tests/test_nvml.cpp
+++ b/tests/test_nvml.cpp
@@ -2,7 +2,7 @@
 #include <vector>
 
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <cudawrappers/cu.hpp>
 #include <cudawrappers/nvml.hpp>
 

--- a/tests/test_nvml.cpp
+++ b/tests/test_nvml.cpp
@@ -1,7 +1,7 @@
+#include <catch2/catch_test_macros.hpp>
 #include <string>
 #include <vector>
 
-#include <catch2/catch_test_macros.hpp>
 #include <cudawrappers/cu.hpp>
 #include <cudawrappers/nvml.hpp>
 

--- a/tests/test_nvml.cpp
+++ b/tests/test_nvml.cpp
@@ -1,7 +1,6 @@
 #include <string>
 #include <vector>
 
-#define CATCH_CONFIG_MAIN
 #include <catch2/catch_test_macros.hpp>
 #include <cudawrappers/cu.hpp>
 #include <cudawrappers/nvml.hpp>

--- a/tests/test_nvrtc.cpp
+++ b/tests/test_nvrtc.cpp
@@ -1,7 +1,7 @@
+#include <catch2/catch_test_macros.hpp>
 #include <string>
 #include <vector>
 
-#include <catch2/catch_test_macros.hpp>
 #include <cudawrappers/nvrtc.hpp>
 
 TEST_CASE("Test nvrtc::Program", "[program]") {

--- a/tests/test_nvrtc.cpp
+++ b/tests/test_nvrtc.cpp
@@ -2,7 +2,7 @@
 #include <vector>
 
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <cudawrappers/nvrtc.hpp>
 
 TEST_CASE("Test nvrtc::Program", "[program]") {

--- a/tests/test_nvrtc.cpp
+++ b/tests/test_nvrtc.cpp
@@ -1,7 +1,6 @@
 #include <string>
 #include <vector>
 
-#define CATCH_CONFIG_MAIN
 #include <catch2/catch_test_macros.hpp>
 #include <cudawrappers/nvrtc.hpp>
 

--- a/tests/test_vector_add.cpp
+++ b/tests/test_vector_add.cpp
@@ -1,10 +1,10 @@
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <cstddef>
 #include <iostream>
 #include <string>
 #include <vector>
 
-#include <catch2/catch_test_macros.hpp>
-#include <catch2/catch_approx.hpp>
 #include <cudawrappers/cu.hpp>
 #include <cudawrappers/nvrtc.hpp>
 

--- a/tests/test_vector_add.cpp
+++ b/tests/test_vector_add.cpp
@@ -4,13 +4,14 @@
 #include <vector>
 
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
 #include <cudawrappers/cu.hpp>
 #include <cudawrappers/nvrtc.hpp>
 
 bool arrays_equal(const float *a, const float *b, size_t n) {
   for (size_t i = 0; i < n; i++) {
-    if (a[i] != Approx(b[i]).epsilon(1e-6)) {
+    if (a[i] != Catch::Approx(b[i]).epsilon(1e-6)) {
       return false;
     }
   }

--- a/tests/test_vector_add.cpp
+++ b/tests/test_vector_add.cpp
@@ -3,7 +3,6 @@
 #include <string>
 #include <vector>
 
-#define CATCH_CONFIG_MAIN
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_approx.hpp>
 #include <cudawrappers/cu.hpp>


### PR DESCRIPTION
**Description**

The C++ standard has been updated to C++14 to support the upgrade of Catch2 to version 3.X. Minor changes to the code were needed because come Catch2 headers and CMake was changed between major version 2 and 3.

**Related issues**:

- https://github.com/nlesc-recruit/cudawrappers/issues/186

**Instructions to review the pull request**

- Check that CHANGELOG.md has been updated if necessary

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```
-->

<!--
Review online.
-->
