### PR TITLE
include cuda_runtime in cu.hpp

### DIFF
--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -15,6 +15,7 @@
 
 #if !defined(__HIP__)
 #include <cuda.h>
+#include <cuda_runtime.h>
 #else
 #include <hip/hip_runtime.h>
 


### PR DESCRIPTION
**Description**

Include `cuda_runtime.h` in `cu.hpp`.

**Related issues**:
See #296 for a description of the problem this PR solves. 
