### PR TITLE
Update target_embed_source to re-run when the sources change

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,7 @@ repos:
     hooks:
       - id: cmake-format
       - id: cmake-lint
+        args: ['--line-width=90']
   - repo: https://github.com/executablebooks/mdformat
     rev: 0.7.17
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
   includes and respects the location of an include in the original source file
 - Upgrade C++ standard to C++14
 - Upgrade Catch2 to version v3.6.0
+- `target_embed_source` is now more robust: it properly tracks dependencies and
+  runs again whenever any of them changes
 
 ## \[0.8.0\] - 2024-07-05
 

--- a/cmake/cudawrappers-helper.cmake
+++ b/cmake/cudawrappers-helper.cmake
@@ -44,7 +44,7 @@ function(target_embed_source target input_file)
     COMMAND
       ${CMAKE_COMMAND} -Dinput_file=${input_file_absolute}
       -Doutput_file=${input_file_inlined} -Droot_dir=${PROJECT_SOURCE_DIR} -P
-      ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/cudawrappers-inline-local-includes.cmake
+      "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/cudawrappers-inline-local-includes.cmake"
     DEPENDS "${input_file_absolute};${include_files}"
     COMMENT "Inlining all includes of ${input_file}"
   )

--- a/cmake/cudawrappers-inline-local-includes.cmake
+++ b/cmake/cudawrappers-inline-local-includes.cmake
@@ -1,0 +1,29 @@
+# Copy the contents of the input file to the output file with all the local
+# includes inlined. Local includes are assumed to have ""'s, e.g. having a line
+# '#include "helper.h"` will lead to `helper.h` being inlined. Only files in the
+# root directory will be considered.
+function(inline_local_includes input_file output_file root_dir)
+  file(READ ${input_file} input_file_contents)
+  set(include_regex "(^|\r?\n)(#include[ \t]*\"([^\"]+)\")")
+  string(REGEX MATCHALL ${include_regex} includes ${input_file_contents})
+  set(include_files "")
+  foreach(include ${includes})
+    # Get the name of the file to include, e.g. 'helper.h'
+    string(REGEX REPLACE ${include_regex} "\\3" include_name ${include})
+    # Get the complete line of the include, e.g.  '#include <helper.h>'
+    string(REGEX REPLACE ${include_regex} "\\2" include_line ${include})
+    file(GLOB_RECURSE INCLUDE_PATHS "${root_dir}/*/${include_name}")
+    if(NOT INCLUDE_PATHS STREQUAL "")
+      list(SORT INCLUDE_PATHS ORDER DESCENDING)
+      list(GET INCLUDE_PATHS 0 include_PATH)
+      list(APPEND include_files ${include_PATH})
+      file(READ ${include_PATH} include_contents)
+      string(REPLACE "${include_line}" "${include_contents}"
+                     input_file_contents "${input_file_contents}"
+      )
+    endif()
+  endforeach()
+  file(WRITE ${output_file} "${input_file_contents}")
+endfunction()
+
+inline_local_includes(${input_file} ${output_file} ${root_dir})


### PR DESCRIPTION
**Description**

The `target_embed_source` helper function didn't properly implement dependency management. This is now changed so that whenever either the kernel source file itself, or any of the local header files that in includes change, a new inlined header file is written and compiled into an object file.

The solution was to use a second `add_custom_command` call used to do the inlining. Using the `DEPENDS` option, dependencies can be specified so that the command runs again when any of them change. This has two consequences:

1. The `inline_local_includes` function had to be moved to a separate file (`cudawrappers-inline-local-includes.cmake`), since the `COMMAND` option for `add_custom_command` can not run a CMake function directly :facepalm: 
2. The part of `inline_local_includes` that retrieves the list of absolute file names for the local include directories had to be replicated (it is called `get_local_includes`) so that we can pass that list to the `DEPENDS` option. Passing the list of paths to `inline_local_includes` to avoid replicated code was considered, but this will only make the code more complicated.


**Related issues**:

- N.A.

**Instructions to review the pull request**

- Check that CHANGELOG.md has been updated if necessary

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```
-->

<!--
Review online.
-->
