### PR TITLE
Add nvml::Device::getPower

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
   `cu::DeviceMemory` object
 - Added `cu::DeviceMemory::memset()`
 - Added `cu::Stream::memsetAsync()`
+- Added `nvml::Device::getPower()`
 
 ### Changed
 

--- a/include/cudawrappers/nvml.hpp
+++ b/include/cudawrappers/nvml.hpp
@@ -54,6 +54,12 @@ class Device {
     return clockMhz;
   }
 
+  unsigned int getPower() {
+    unsigned int power;
+    checkNvmlCall(nvmlDeviceGetPowerUsage(device_, &power));
+    return power;
+  }
+
  private:
   nvmlDevice_t device_;
 };

--- a/tests/test_nvml.cpp
+++ b/tests/test_nvml.cpp
@@ -20,6 +20,13 @@ TEST_CASE("Test nvml::Device::getClock", "[device]") {
   REQUIRE(clockMHz > 0);
 }
 
+TEST_CASE("Test nvml::Device::getPower", "[device]") {
+  nvml::Context context;
+  nvml::Device device(context, 0);
+  const unsigned int power = device.getPower();
+  REQUIRE(power > 0);
+}
+
 TEST_CASE("Test nvml::Device with device", "[device]") {
   cu::init();
   cu::Device cu_device(0);


### PR DESCRIPTION
**Description**

Support for `nvmlFieldValue_t` was added in CUDA 12 and can (amongst other things) be used to query power usage for a CUDA device. In earlier CUDA versions (e.g. CUDA 11.8), it was common to use `nvmlDeviceGetPowerUsage`, but it is missing from the API. This function has therefore been added to the `nvml::Device` class as `getPower` so that one can query power usage even when using older versions of CUDA.

**Related issues**:

- N.A.

**Instructions to review the pull request**

- Check that CHANGELOG.md has been updated if necessary

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```
-->

<!--
Review online.
-->
