### PR TITLE
Added support for 2D operations and C2R/R2C FFT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,12 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Added `cu::DeviceMemory::memset()`
 - Added `cu::Stream::memsetAsync()`
 - Added `nvml::Device::getPower()`
-- Added 2D memcpy and memset operations
-- Added `FFT1DRealToComplex` and `FFT1DComplexToReal`
+- Added `cu::Stream::memcpyHtoD2DAsync()`, `cu::Stream::memcpyDtoHD2Async()`,
+  and `cu::Stream::memcpyDtoD2DAsync()` for 2D asynchronous memory copies.
+- Added `cu::DeviceMemory::memset2D()` and `cu::Stream::memset2DAsync()` for 2D
+  memsets
+- Added `cufft::FFT1D_R2C` and `cufft::FFT1D_C2R` for 1D real-to-complex and
+  vice verse FFT
 
 ### Changed
 
@@ -26,6 +30,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Upgrade Catch2 to version v3.6.0
 - `target_embed_source` is now more robust: it properly tracks dependencies and
   runs again whenever any of them changes
+- Expanded tests to cover the new 2D memory operations and FFT support
 
 ## \[0.8.0\] - 2024-07-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Added `cu::DeviceMemory::memset()`
 - Added `cu::Stream::memsetAsync()`
 - Added `nvml::Device::getPower()`
+- Added 2D memcpy and memset operations
+- Added `FFT1DRealToComplex` and `FFT1DComplexToReal` 
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Added `cu::Stream::memsetAsync()`
 - Added `nvml::Device::getPower()`
 - Added 2D memcpy and memset operations
-- Added `FFT1DRealToComplex` and `FFT1DComplexToReal` 
+- Added `FFT1DRealToComplex` and `FFT1DComplexToReal`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
   memsets
 - Added `cufft::FFT1D_R2C` and `cufft::FFT1D_C2R` for 1D real-to-complex and
   vice versa FFT
+- Added cu::Device::getOrdinal().
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Added `cu::Stream::memcpyHtoD2DAsync()`, `cu::Stream::memcpyDtoHD2Async()`,
   and `cu::Stream::memcpyDtoD2DAsync()`
 - Added `cu::DeviceMemory::memset2D()` and `cu::Stream::memset2DAsync()`
-- Added `cufft::FFT1D_R2C` and `cufft::FFT1D_C2R`
+- Added `cufft::FFT1DR2C` and `cufft::FFT1DC2R`
 - Added `cu::Device::getOrdinal()`
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,10 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Added `cu::Stream::memsetAsync()`
 - Added `nvml::Device::getPower()`
 - Added `cu::Stream::memcpyHtoD2DAsync()`, `cu::Stream::memcpyDtoHD2Async()`,
-  and `cu::Stream::memcpyDtoD2DAsync()` for 2D asynchronous memory copies.
-- Added `cu::DeviceMemory::memset2D()` and `cu::Stream::memset2DAsync()` for 2D
-  memsets
-- Added `cufft::FFT1D_R2C` and `cufft::FFT1D_C2R` for 1D real-to-complex and
-  vice versa FFT
-- Added cu::Device::getOrdinal().
+  and `cu::Stream::memcpyDtoD2DAsync()`
+- Added `cu::DeviceMemory::memset2D()` and `cu::Stream::memset2DAsync()`
+- Added `cufft::FFT1D_R2C` and `cufft::FFT1D_C2R`
+- Added `cu::Device::getOrdinal()`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Added `cu::DeviceMemory::memset2D()` and `cu::Stream::memset2DAsync()` for 2D
   memsets
 - Added `cufft::FFT1D_R2C` and `cufft::FFT1D_C2R` for 1D real-to-complex and
-  vice verse FFT
+  vice versa FFT
 
 ### Changed
 

--- a/README.dev.md
+++ b/README.dev.md
@@ -299,5 +299,5 @@ To view the generated documentation, open `_build/html/index.html` in your web-b
 
 ### Verification
 
-1. Make sure the new release is added to Zenodo (see <https://zenodo.org/record/6076447>)
+1. Make sure the new release is added to Zenodo (see <https://zenodo.org/records/8075251>)
 1. Activate the latest release documentation at <https://readthedocs.org/projects/cudawrappers/versions/>

--- a/cmake/cudawrappers-helper.cmake
+++ b/cmake/cudawrappers-helper.cmake
@@ -1,4 +1,4 @@
-# Retun a list of asbolute file names for all the local includes of the
+# Return a list of absolute file names for all the local includes of the
 # input_file.  Only files in the root directory will be considered.
 function(get_local_includes input_file root_dir)
   file(READ ${input_file} input_file_contents)

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -23,7 +23,6 @@
 #include <cudawrappers/macros.hpp>
 #endif
 
-
 namespace cu {
 class Error : public std::exception {
  public:
@@ -190,7 +189,8 @@ class Device : public Wrapper<CUdevice> {
   }
 
   size_t getTotalConstMem() const {
-    return static_cast<size_t>(getAttribute(CU_DEVICE_ATTRIBUTE_TOTAL_CONSTANT_MEMORY));
+    return static_cast<size_t>(
+        getAttribute(CU_DEVICE_ATTRIBUTE_TOTAL_CONSTANT_MEMORY));
   }
 
   // Primary Context Management
@@ -602,28 +602,29 @@ class DeviceMemory : public Wrapper<CUdeviceptr> {
     checkCudaCall(cuMemsetD32(_obj, value, size));
   }
 
-  void memset2D(unsigned char value, size_t size, size_t width, size_t height) {
-    checkCudaCall(cuMemsetD2D8(_obj, value, size, width, height));
+  void memset2D(unsigned char value, size_t pitch, size_t width,
+                size_t height) {
+    checkCudaCall(cuMemsetD2D8(_obj, pitch, value, width, height));
   }
 
-  void memset2D(unsigned short value, size_t size, size_t width, size_t height) {
-    checkCudaCall(cuMemsetD2D16(_obj, value, size, width, height));
+  void memset2D(unsigned short value, size_t pitch, size_t width,
+                size_t height) {
+    checkCudaCall(cuMemsetD2D16(_obj, pitch, value, width, height));
   }
 
-  void memset2D(unsigned int value, size_t size, size_t width, size_t height) {
-    checkCudaCall(cuMemsetD2D32(_obj, value, size, width, height));
+  void memset2D(unsigned int value, size_t pitch, size_t width, size_t height) {
+    checkCudaCall(cuMemsetD2D32(_obj, pitch, value, width, height));
   }
 
-  void zero(size_t size) {
-    memset(static_cast<unsigned char>(0), size);
-  }
+  void zero(size_t size) { memset(static_cast<unsigned char>(0), size); }
 
   void memcpyToSymbolSync(const void *symbol, size_t count, size_t offset) {
-    if (cudaMemcpyToSymbol(symbol,reinterpret_cast<const void*>(_obj), count, offset, cudaMemcpyDeviceToDevice) != cudaSuccess) {
+    if (cudaMemcpyToSymbol(symbol, reinterpret_cast<const void *>(_obj), count,
+                           offset, cudaMemcpyDeviceToDevice) != cudaSuccess) {
       throw cu::Error(CUDA_ERROR_UNKNOWN);
     }
   }
-  
+
   const void *parameter()
       const  // used to construct parameter list for launchKernel();
   {
@@ -631,10 +632,7 @@ class DeviceMemory : public Wrapper<CUdeviceptr> {
   }
 
   // FIXME: remove this function.
-  void *parameter_copy_temp()
-  {
-    return reinterpret_cast<void*>(_obj);
-  }
+  void *parameter_copy_temp() { return reinterpret_cast<void *>(_obj); }
 
   template <typename T>
   operator T *() {
@@ -701,10 +699,12 @@ class Stream : public Wrapper<CUstream> {
 #endif
   }
 
-  void memcpyHtoD2DAsync(DeviceMemory &devPtr, size_t dpitch, const void *hostPtr, size_t spitch, size_t width, size_t height) {
+  void memcpyHtoD2DAsync(DeviceMemory &devPtr, size_t dpitch,
+                         const void *hostPtr, size_t spitch, size_t width,
+                         size_t height) {
 #if defined(__HIP__)
-    // FIXME: implement for HIP
-    #error "memcpyHtoD2DAsync not yet implemented for HIP"
+// FIXME: implement for HIP
+#error "memcpyHtoD2DAsync not yet implemented for HIP"
 #else
     // Initialize the CUDA_MEMCPY2D structure
     CUDA_MEMCPY2D copyParams = {0};
@@ -733,10 +733,12 @@ class Stream : public Wrapper<CUstream> {
 #endif
   }
 
-  void memcpyDtoH2DAsync(void *hostPtr, size_t dpitch, const DeviceMemory &devPtr, size_t spitch, size_t width, size_t height) {
+  void memcpyDtoH2DAsync(void *hostPtr, size_t dpitch,
+                         const DeviceMemory &devPtr, size_t spitch,
+                         size_t width, size_t height) {
 #if defined(__HIP__)
-    // FIXME: implement for HIP
-    #error "memcpyDtoH2DAsync not yet implemented for HIP"
+// FIXME: implement for HIP
+#error "memcpyDtoH2DAsync not yet implemented for HIP"
 #else
     // Initialize the CUDA_MEMCPY2D structure
     CUDA_MEMCPY2D copyParams = {0};
@@ -811,16 +813,21 @@ class Stream : public Wrapper<CUstream> {
     checkCudaCall(cuMemsetD32Async(devPtr, value, size, _obj));
   }
 
-  void memset2DAsync(DeviceMemory &devPtr, unsigned char value, size_t pitch, size_t width, size_t height) {
+  void memset2DAsync(DeviceMemory &devPtr, unsigned char value, size_t pitch,
+                     size_t width, size_t height) {
     checkCudaCall(cuMemsetD2D8Async(devPtr, pitch, value, width, height, _obj));
   }
 
-  void memset2DAsync(DeviceMemory &devPtr, unsigned short value, size_t pitch, size_t width, size_t height) {
-    checkCudaCall(cuMemsetD2D16Async(devPtr, pitch, value, width, height, _obj));
+  void memset2DAsync(DeviceMemory &devPtr, unsigned short value, size_t pitch,
+                     size_t width, size_t height) {
+    checkCudaCall(
+        cuMemsetD2D16Async(devPtr, pitch, value, width, height, _obj));
   }
 
-  void memset2DAsync(DeviceMemory &devPtr, int value, size_t pitch, size_t width, size_t height) {
-    checkCudaCall(cuMemsetD2D32Async(devPtr, pitch, value, width, height, _obj));
+  void memset2DAsync(DeviceMemory &devPtr, unsigned int value, size_t pitch,
+                     size_t width, size_t height) {
+    checkCudaCall(
+        cuMemsetD2D32Async(devPtr, pitch, value, width, height, _obj));
   }
 
   void zero(DeviceMemory &devPtr, size_t size) {
@@ -887,7 +894,8 @@ inline void Event::record(Stream &stream) {
   checkCudaCall(cuEventRecord(_obj, stream._obj));
 }
 
-// inline void memcpyToSymbolSync(const void *symbol, cu::DeviceMemory &src, size_t count, size_t offset) {
+// inline void memcpyToSymbolSync(const void *symbol, cu::DeviceMemory &src,
+// size_t count, size_t offset) {
 //   // cudaMemcpyToSymbolAsync(c_killmask, src, count, offset,
 //   //                       cudaMemcpyDeviceToDevice, stream);
 //   #if defined(__HIP__)
@@ -895,27 +903,27 @@ inline void Event::record(Stream &stream) {
 //   #error "memcpyToSymbolAsync not yet implemented for HIP"
 //   #else
 
-//   // FIXME: find the 'cu' equivalent of cudaMemcpyToSymbolAsync, i.e. cuMemcpyToSymbolAsync
-//   // checkCudaCall(cudaMemcpyToSymbol(symbol, src, count, offset, cudaMemcpyDeviceToDevice));
+//   // FIXME: find the 'cu' equivalent of cudaMemcpyToSymbolAsync, i.e.
+//   cuMemcpyToSymbolAsync
+//   // checkCudaCall(cudaMemcpyToSymbol(symbol, src, count, offset,
+//   cudaMemcpyDeviceToDevice));
 
-
-//   if (cudaMemcpyToSymbol(symbol, src.parameter_by_copy(), count, offset, cudaMemcpyDeviceToDevice) != cudaSuccess) {
+//   if (cudaMemcpyToSymbol(symbol, src.parameter_by_copy(), count, offset,
+//   cudaMemcpyDeviceToDevice) != cudaSuccess) {
 //     throw cu::Error(CUDA_ERROR_UNKNOWN);
 //   }
 
-
-//   // CUresult cuModuleGetGlobal ( CUdeviceptr* dptr, size_t* bytes, CUmodule hmod, const char* name )
+//   // CUresult cuModuleGetGlobal ( CUdeviceptr* dptr, size_t* bytes, CUmodule
+//   hmod, const char* name )
 //   // CUdeviceptr dptr = nullptr;
 //   // size_t dsize = 0;
 
 //   // checkCudaCall(cuModuleGetGlobal())
 
-//   // checkCudaCall(cuMemcpyToSymbolAsync(symbol, src, count, cudaMemcpyDeviceToDevice, _obj));
-//   #endif
+//   // checkCudaCall(cuMemcpyToSymbolAsync(symbol, src, count,
+//   cudaMemcpyDeviceToDevice, _obj)); #endif
 // }
 
 }  // namespace cu
-
-
 
 #endif

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -101,7 +101,6 @@ class Wrapper {
         &memoryType, CU_POINTER_ATTRIBUTE_MEMORY_TYPE, pointer));
 
     // Check if the memoryType is one of the allowed memory types
-    bool isAllowed = false;
     for (auto allowedType : {AllowedMemoryTypes...}) {
       if (memoryType == allowedType) return;
     }

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -193,6 +193,8 @@ class Device : public Wrapper<CUdevice> {
         getAttribute(CU_DEVICE_ATTRIBUTE_TOTAL_CONSTANT_MEMORY));
   }
 
+  int getOrdinal() const { return _ordinal; }
+
   // Primary Context Management
   std::pair<unsigned, bool> primaryCtxGetState() const {
     unsigned flags{};

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -102,7 +102,9 @@ class Wrapper {
 
     // Check if the memoryType is one of the allowed memory types
     for (auto allowedType : {AllowedMemoryTypes...}) {
-      if (memoryType == allowedType) return;
+      if (memoryType == allowedType) {
+            return;
+      }
     }
 
     throw std::runtime_error(

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -103,7 +103,7 @@ class Wrapper {
     // Check if the memoryType is one of the allowed memory types
     for (auto allowedType : {AllowedMemoryTypes...}) {
       if (memoryType == allowedType) {
-            return;
+        return;
       }
     }
 

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -189,7 +189,6 @@ class Device : public Wrapper<CUdevice> {
   }
 
   size_t getTotalConstMem() const {
-    // FIXME: implement HIP.
     return static_cast<size_t>(
         getAttribute(CU_DEVICE_ATTRIBUTE_TOTAL_CONSTANT_MEMORY));
   }
@@ -636,9 +635,7 @@ class DeviceMemory : public Wrapper<CUdeviceptr> {
   {
     return &_obj;
   }
-
-  // FIXME: remove this function.
-  void *parameter_copy_temp() { return reinterpret_cast<void *>(_obj); }
+  void *parameter_copy() { return reinterpret_cast<void *>(_obj); }
 
   template <typename T>
   operator T *() {
@@ -911,37 +908,6 @@ class Stream : public Wrapper<CUstream> {
 inline void Event::record(Stream &stream) {
   checkCudaCall(cuEventRecord(_obj, stream._obj));
 }
-
-// inline void memcpyToSymbolSync(const void *symbol, cu::DeviceMemory &src,
-// size_t count, size_t offset) {
-//   // cudaMemcpyToSymbolAsync(c_killmask, src, count, offset,
-//   //                       cudaMemcpyDeviceToDevice, stream);
-//   #if defined(__HIP__)
-//   // FIXME: finish HIP implementation.
-//   #error "memcpyToSymbolAsync not yet implemented for HIP"
-//   #else
-
-//   // FIXME: find the 'cu' equivalent of cudaMemcpyToSymbolAsync, i.e.
-//   cuMemcpyToSymbolAsync
-//   // checkCudaCall(cudaMemcpyToSymbol(symbol, src, count, offset,
-//   cudaMemcpyDeviceToDevice));
-
-//   if (cudaMemcpyToSymbol(symbol, src.parameter_by_copy(), count, offset,
-//   cudaMemcpyDeviceToDevice) != cudaSuccess) {
-//     throw cu::Error(CUDA_ERROR_UNKNOWN);
-//   }
-
-//   // CUresult cuModuleGetGlobal ( CUdeviceptr* dptr, size_t* bytes, CUmodule
-//   hmod, const char* name )
-//   // CUdeviceptr dptr = nullptr;
-//   // size_t dsize = 0;
-
-//   // checkCudaCall(cuModuleGetGlobal())
-
-//   // checkCudaCall(cuMemcpyToSymbolAsync(symbol, src, count,
-//   cudaMemcpyDeviceToDevice, _obj)); #endif
-// }
-
 }  // namespace cu
 
 #endif

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -605,35 +605,31 @@ class DeviceMemory : public Wrapper<CUdeviceptr> {
 
   void memset2D(unsigned char value, size_t pitch, size_t width,
                 size_t height) {
+#if defined(__HIP__)
+    checkCudaCall(hipMemset2D(_obj, pitch, value, width, height));
+#else
     checkCudaCall(cuMemsetD2D8(_obj, pitch, value, width, height));
+#endif
   }
 
   void memset2D(unsigned short value, size_t pitch, size_t width,
                 size_t height) {
+#if defined(__HIP__)
+    checkCudaCall(hipMemset2D(_obj, pitch, value, width, height));
+#else
     checkCudaCall(cuMemsetD2D16(_obj, pitch, value, width, height));
+#endif
   }
 
   void memset2D(unsigned int value, size_t pitch, size_t width, size_t height) {
+#if defined(__HIP__)
+    checkCudaCall(hipMemset2D(_obj, pitch, value, width, height));
+#else
     checkCudaCall(cuMemsetD2D32(_obj, pitch, value, width, height));
+#endif
   }
 
   void zero(size_t size) { memset(static_cast<unsigned char>(0), size); }
-
-  void memcpyToSymbolAsync(const void *symbol, size_t count, size_t offset,
-                           cudaStream_t stream) {
-    if (cudaMemcpyToSymbolAsync(symbol, reinterpret_cast<const void *>(_obj),
-                                count, offset, cudaMemcpyDeviceToDevice,
-                                stream) != cudaSuccess) {
-      throw cu::Error(CUDA_ERROR_UNKNOWN);
-    }
-  }
-
-  void memcpyToSymbolSync(const void *symbol, size_t count, size_t offset) {
-    if (cudaMemcpyToSymbol(symbol, reinterpret_cast<const void *>(_obj), count,
-                           offset, cudaMemcpyDeviceToDevice) != cudaSuccess) {
-      throw cu::Error(CUDA_ERROR_UNKNOWN);
-    }
-  }
 
   const void *parameter()
       const  // used to construct parameter list for launchKernel();
@@ -713,8 +709,8 @@ class Stream : public Wrapper<CUstream> {
                          const void *hostPtr, size_t spitch, size_t width,
                          size_t height) {
 #if defined(__HIP__)
-// FIXME: implement for HIP
-#error "memcpyHtoD2DAsync not yet implemented for HIP"
+    checkCudaCall(hipMemcpy2DAsync(devPtr, dpitch, hostPtr, spitch, width,
+                                   height, hipMemcpyHostToDevice, _obj));
 #else
     // Initialize the CUDA_MEMCPY2D structure
     CUDA_MEMCPY2D copyParams = {0};
@@ -747,8 +743,8 @@ class Stream : public Wrapper<CUstream> {
                          const DeviceMemory &devPtr, size_t spitch,
                          size_t width, size_t height) {
 #if defined(__HIP__)
-// FIXME: implement for HIP
-#error "memcpyDtoH2DAsync not yet implemented for HIP"
+    checkCudaCall(hipMemcpy2DAsync(hostPtr, dpitch, devPtr, spitch, width,
+                                   height, hipMemcpyDeviceToHost, _obj));
 #else
     // Initialize the CUDA_MEMCPY2D structure
     CUDA_MEMCPY2D copyParams = {0};
@@ -825,19 +821,31 @@ class Stream : public Wrapper<CUstream> {
 
   void memset2DAsync(DeviceMemory &devPtr, unsigned char value, size_t pitch,
                      size_t width, size_t height) {
+#if defined(__HIP__)
+    checkCudaCall(hipMemset2DAsync(devPtr, pitch, value, width, height, _obj));
+#else
     checkCudaCall(cuMemsetD2D8Async(devPtr, pitch, value, width, height, _obj));
+#endif
   }
 
   void memset2DAsync(DeviceMemory &devPtr, unsigned short value, size_t pitch,
                      size_t width, size_t height) {
+#if defined(__HIP__)
+    checkCudaCall(hipMemset2DAsync(devPtr, pitch, value, width, height, _obj));
+#else
     checkCudaCall(
         cuMemsetD2D16Async(devPtr, pitch, value, width, height, _obj));
+#endif
   }
 
   void memset2DAsync(DeviceMemory &devPtr, unsigned int value, size_t pitch,
                      size_t width, size_t height) {
+#if defined(__HIP__)
+    checkCudaCall(hipMemset2DAsync(devPtr, pitch, value, width, height, _obj));
+#else
     checkCudaCall(
         cuMemsetD2D32Async(devPtr, pitch, value, width, height, _obj));
+#endif
   }
 
   void zero(DeviceMemory &devPtr, size_t size) {

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -23,6 +23,7 @@
 #include <cudawrappers/macros.hpp>
 #endif
 
+
 namespace cu {
 class Error : public std::exception {
  public:
@@ -186,6 +187,10 @@ class Device : public Wrapper<CUdevice> {
     size_t size{};
     checkCudaCall(cuDeviceTotalMem(&size, _obj));
     return size;
+  }
+
+  size_t getTotalConstMem() const {
+    return static_cast<size_t>(getAttribute(CU_DEVICE_ATTRIBUTE_TOTAL_CONSTANT_MEMORY));
   }
 
   // Primary Context Management
@@ -597,12 +602,38 @@ class DeviceMemory : public Wrapper<CUdeviceptr> {
     checkCudaCall(cuMemsetD32(_obj, value, size));
   }
 
-  void zero(size_t size) { memset(static_cast<unsigned char>(0), size); }
+  void memset2D(unsigned char value, size_t size, size_t width, size_t height) {
+    checkCudaCall(cuMemsetD2D8(_obj, value, size, width, height));
+  }
 
+  void memset2D(unsigned short value, size_t size, size_t width, size_t height) {
+    checkCudaCall(cuMemsetD2D16(_obj, value, size, width, height));
+  }
+
+  void memset2D(unsigned int value, size_t size, size_t width, size_t height) {
+    checkCudaCall(cuMemsetD2D32(_obj, value, size, width, height));
+  }
+
+  void zero(size_t size) {
+    memset(static_cast<unsigned char>(0), size);
+  }
+
+  void memcpyToSymbolSync(const void *symbol, size_t count, size_t offset) {
+    if (cudaMemcpyToSymbol(symbol,reinterpret_cast<const void*>(_obj), count, offset, cudaMemcpyDeviceToDevice) != cudaSuccess) {
+      throw cu::Error(CUDA_ERROR_UNKNOWN);
+    }
+  }
+  
   const void *parameter()
       const  // used to construct parameter list for launchKernel();
   {
     return &_obj;
+  }
+
+  // FIXME: remove this function.
+  void *parameter_copy_temp()
+  {
+    return reinterpret_cast<void*>(_obj);
   }
 
   template <typename T>
@@ -670,6 +701,70 @@ class Stream : public Wrapper<CUstream> {
 #endif
   }
 
+  void memcpyHtoD2DAsync(DeviceMemory &devPtr, size_t dpitch, const void *hostPtr, size_t spitch, size_t width, size_t height) {
+#if defined(__HIP__)
+    // FIXME: implement for HIP
+    #error "memcpyHtoD2DAsync not yet implemented for HIP"
+#else
+    // Initialize the CUDA_MEMCPY2D structure
+    CUDA_MEMCPY2D copyParams = {0};
+
+    // Set width and height for the 2D copy
+    copyParams.WidthInBytes = width;
+    copyParams.Height = height;
+
+    // Set the destination (dst)
+    copyParams.dstXInBytes = 0;
+    copyParams.dstY = 0;
+    copyParams.dstPitch = dpitch;
+
+    // Set the source (src)
+    copyParams.srcXInBytes = 0;
+    copyParams.srcY = 0;
+    copyParams.srcPitch = spitch;
+
+    copyParams.srcMemoryType = CU_MEMORYTYPE_HOST;
+    copyParams.dstMemoryType = CU_MEMORYTYPE_DEVICE;
+    copyParams.srcHost = hostPtr;
+    copyParams.dstDevice = devPtr;
+
+    // Call the driver API function cuMemcpy2DAsync
+    checkCudaCall(cuMemcpy2DAsync(&copyParams, _obj));
+#endif
+  }
+
+  void memcpyDtoH2DAsync(void *hostPtr, size_t dpitch, const DeviceMemory &devPtr, size_t spitch, size_t width, size_t height) {
+#if defined(__HIP__)
+    // FIXME: implement for HIP
+    #error "memcpyDtoH2DAsync not yet implemented for HIP"
+#else
+    // Initialize the CUDA_MEMCPY2D structure
+    CUDA_MEMCPY2D copyParams = {0};
+
+    // Set width and height for the 2D copy
+    copyParams.WidthInBytes = width;
+    copyParams.Height = height;
+
+    // Set the destination (dst)
+    copyParams.dstXInBytes = 0;
+    copyParams.dstY = 0;
+    copyParams.dstPitch = dpitch;
+
+    // Set the source (src)
+    copyParams.srcXInBytes = 0;
+    copyParams.srcY = 0;
+    copyParams.srcPitch = spitch;
+
+    copyParams.srcMemoryType = CU_MEMORYTYPE_DEVICE;
+    copyParams.dstMemoryType = CU_MEMORYTYPE_HOST;
+    copyParams.srcDevice = devPtr;
+    copyParams.dstHost = hostPtr;
+
+    // Call the driver API function cuMemcpy2DAsync
+    checkCudaCall(cuMemcpy2DAsync(&copyParams, _obj));
+#endif
+  }
+
   void memcpyHtoDAsync(CUdeviceptr devPtr, const void *hostPtr, size_t size) {
 #if defined(__HIP__)
     checkCudaCall(
@@ -716,8 +811,24 @@ class Stream : public Wrapper<CUstream> {
     checkCudaCall(cuMemsetD32Async(devPtr, value, size, _obj));
   }
 
+  void memset2DAsync(DeviceMemory &devPtr, unsigned char value, size_t pitch, size_t width, size_t height) {
+    checkCudaCall(cuMemsetD2D8Async(devPtr, pitch, value, width, height, _obj));
+  }
+
+  void memset2DAsync(DeviceMemory &devPtr, unsigned short value, size_t pitch, size_t width, size_t height) {
+    checkCudaCall(cuMemsetD2D16Async(devPtr, pitch, value, width, height, _obj));
+  }
+
+  void memset2DAsync(DeviceMemory &devPtr, int value, size_t pitch, size_t width, size_t height) {
+    checkCudaCall(cuMemsetD2D32Async(devPtr, pitch, value, width, height, _obj));
+  }
+
   void zero(DeviceMemory &devPtr, size_t size) {
     memsetAsync(devPtr, static_cast<unsigned char>(0), size);
+  }
+
+  void zero2D(DeviceMemory &devPtr, size_t pitch, size_t width, size_t height) {
+    memset2DAsync(devPtr, static_cast<unsigned char>(0), pitch, width, height);
   }
 
   void launchKernel(Function &function, unsigned gridX, unsigned gridY,
@@ -775,6 +886,36 @@ class Stream : public Wrapper<CUstream> {
 inline void Event::record(Stream &stream) {
   checkCudaCall(cuEventRecord(_obj, stream._obj));
 }
+
+// inline void memcpyToSymbolSync(const void *symbol, cu::DeviceMemory &src, size_t count, size_t offset) {
+//   // cudaMemcpyToSymbolAsync(c_killmask, src, count, offset,
+//   //                       cudaMemcpyDeviceToDevice, stream);
+//   #if defined(__HIP__)
+//   // FIXME: finish HIP implementation.
+//   #error "memcpyToSymbolAsync not yet implemented for HIP"
+//   #else
+
+//   // FIXME: find the 'cu' equivalent of cudaMemcpyToSymbolAsync, i.e. cuMemcpyToSymbolAsync
+//   // checkCudaCall(cudaMemcpyToSymbol(symbol, src, count, offset, cudaMemcpyDeviceToDevice));
+
+
+//   if (cudaMemcpyToSymbol(symbol, src.parameter_by_copy(), count, offset, cudaMemcpyDeviceToDevice) != cudaSuccess) {
+//     throw cu::Error(CUDA_ERROR_UNKNOWN);
+//   }
+
+
+//   // CUresult cuModuleGetGlobal ( CUdeviceptr* dptr, size_t* bytes, CUmodule hmod, const char* name )
+//   // CUdeviceptr dptr = nullptr;
+//   // size_t dsize = 0;
+
+//   // checkCudaCall(cuModuleGetGlobal())
+
+//   // checkCudaCall(cuMemcpyToSymbolAsync(symbol, src, count, cudaMemcpyDeviceToDevice, _obj));
+//   #endif
+// }
+
 }  // namespace cu
+
+
 
 #endif

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -1,4 +1,3 @@
-#include <sys/resource.h>
 #if !defined CU_WRAPPER_H
 #define CU_WRAPPER_H
 

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -189,6 +189,7 @@ class Device : public Wrapper<CUdevice> {
   }
 
   size_t getTotalConstMem() const {
+    // FIXME: implement HIP.
     return static_cast<size_t>(
         getAttribute(CU_DEVICE_ATTRIBUTE_TOTAL_CONSTANT_MEMORY));
   }
@@ -617,6 +618,15 @@ class DeviceMemory : public Wrapper<CUdeviceptr> {
   }
 
   void zero(size_t size) { memset(static_cast<unsigned char>(0), size); }
+
+  void memcpyToSymbolAsync(const void *symbol, size_t count, size_t offset,
+                           cudaStream_t stream) {
+    if (cudaMemcpyToSymbolAsync(symbol, reinterpret_cast<const void *>(_obj),
+                                count, offset, cudaMemcpyDeviceToDevice,
+                                stream) != cudaSuccess) {
+      throw cu::Error(CUDA_ERROR_UNKNOWN);
+    }
+  }
 
   void memcpyToSymbolSync(const void *symbol, size_t count, size_t offset) {
     if (cudaMemcpyToSymbol(symbol, reinterpret_cast<const void *>(_obj), count,

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -182,7 +182,7 @@ class Device : public Wrapper<CUdevice> {
 #endif
   }
 
-  size_t totalMem() const {
+  size_t getTotalMem() const {
     size_t size{};
     checkCudaCall(cuDeviceTotalMem(&size, _obj));
     return size;

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -182,15 +182,10 @@ class Device : public Wrapper<CUdevice> {
 #endif
   }
 
-  size_t getTotalMem() const {
+  size_t totalMem() const {
     size_t size{};
     checkCudaCall(cuDeviceTotalMem(&size, _obj));
     return size;
-  }
-
-  size_t getTotalConstMem() const {
-    return static_cast<size_t>(
-        getAttribute(CU_DEVICE_ATTRIBUTE_TOTAL_CONSTANT_MEMORY));
   }
 
   int getOrdinal() const { return _ordinal; }

--- a/include/cudawrappers/cufft.hpp
+++ b/include/cudawrappers/cufft.hpp
@@ -12,6 +12,7 @@
 #endif
 
 #include <exception>
+#include <array>
 
 #include "cudawrappers/cu.hpp"
 
@@ -224,6 +225,78 @@ FFT2D<CUDA_C_16F>::FFT2D(int nx, int ny, int stride, int dist, int batch) {
 template <>
 FFT2D<CUDA_C_16F>::FFT2D(int nx, int ny) : FFT2D(nx, ny, 1, nx * ny, 1) {}
 
+/*
+ * FFT1DRealToComplex
+ */
+template <cudaDataType_t T>
+class FFT1DRealToComplex : public FFT {
+ public:
+#if defined(__HIP__)
+  __host__
+#endif
+  FFT1DRealToComplex(int nx) = delete;
+#if defined(__HIP__)
+  __host__
+#endif
+  FFT1DRealToComplex(int nx, int batch) = delete;
+
+  FFT1DRealToComplex(int nx, int batch, std::array<long long, 1>& inembed, std::array<long long, 1>& ouembed) = delete;
+};
+
+
+template <>
+FFT1DRealToComplex<CUDA_R_32F>::FFT1DRealToComplex(int nx, int batch, std::array<long long, 1>& inembed, std::array<long long, 1>& ouembed) {
+  checkCuFFTCall(cufftCreate(plan()));
+  const int rank = 1;
+  size_t ws = 0;
+  std::array<long long, 1> n{nx};
+  long long int idist = inembed[0];
+  long long int odist = ouembed[0];
+  int istride = 1;
+  int ostride = 1;
+  checkCuFFTCall(cufftXtMakePlanMany(*plan(), rank, n.data(), inembed.data(), istride,
+                                     idist, CUDA_R_32F, ouembed.data(), ostride, odist,
+                                     CUDA_C_32F, batch, &ws, CUDA_R_32F));
+}
+
+/*
+ * FFT1DComplexToReal
+ */
+template <cudaDataType_t T>
+class FFT1DComplexToReal : public FFT {
+ public:
+#if defined(__HIP__)
+  __host__
+#endif
+  FFT1DComplexToReal(int nx) = delete;
+#if defined(__HIP__)
+  __host__
+#endif
+  FFT1DComplexToReal(int nx, int batch) = delete;
+
+  FFT1DComplexToReal(int nx, int batch, std::array<long long, 1>& inembed, std::array<long long, 1>& ouembed) = delete;
+};
+
+
+template <>
+FFT1DComplexToReal<CUDA_C_32F>::FFT1DComplexToReal(int nx, int batch, std::array<long long, 1>& inembed, std::array<long long, 1>& ouembed) {
+  checkCuFFTCall(cufftCreate(plan()));
+  const int rank = 1;
+  size_t ws = 0;
+  std::array<long long, 1> n{nx};
+  long long int idist = inembed[0];
+  long long int odist = ouembed[0];
+  int istride = 1;
+  int ostride = 1;
+  checkCuFFTCall(cufftXtMakePlanMany(*plan(), rank, n.data(), inembed.data(), istride,
+                                     idist, CUDA_C_32F, ouembed.data(), ostride, odist,
+                                     CUDA_R_32F, batch, &ws, CUDA_C_32F));
+}
+
+
 }  // namespace cufft
+
+
+
 
 #endif  // CUFFT_H

--- a/include/cudawrappers/cufft.hpp
+++ b/include/cudawrappers/cufft.hpp
@@ -231,30 +231,30 @@ FFT2D<CUDA_C_16F>::FFT2D(const int nx, const int ny)
     : FFT2D(nx, ny, 1, nx * ny, 1) {}
 
 /*
- * FFT1D_R2C
+ * FFT1DR2C
  */
 template <cudaDataType_t T>
-class FFT1D_R2C : public FFT {
+class FFT1DR2C : public FFT {
  public:
 #if defined(__HIP__)
   __host__
 #endif
-  FFT1D_R2C(const int nx) = delete;
+  FFT1DR2C(const int nx) = delete;
 #if defined(__HIP__)
   __host__
 #endif
-  FFT1D_R2C(const int nx, const int batch) = delete;
+  FFT1DR2C(const int nx, const int batch) = delete;
 
 #if defined(__HIP__)
   __host__
 #endif
-  FFT1D_R2C(const int nx, const int batch, long long inembed,
-            long long ouembed) = delete;
+  FFT1DR2C(const int nx, const int batch, long long inembed,
+           long long ouembed) = delete;
 };
 
 template <>
-FFT1D_R2C<CUDA_R_32F>::FFT1D_R2C(const int nx, const int batch,
-                                 long long inembed, long long ouembed) {
+FFT1DR2C<CUDA_R_32F>::FFT1DR2C(const int nx, const int batch, long long inembed,
+                               long long ouembed) {
   checkCuFFTCall(cufftCreate(plan()));
   const int rank = 1;
   size_t ws = 0;
@@ -273,26 +273,26 @@ FFT1D_R2C<CUDA_R_32F>::FFT1D_R2C(const int nx, const int batch,
  * FFT1D_C2R
  */
 template <cudaDataType_t T>
-class FFT1D_C2R : public FFT {
+class FFT1DC2R : public FFT {
  public:
 #if defined(__HIP__)
   __host__
 #endif
-  FFT1D_C2R(const int nx) = delete;
+  FFT1DC2R(const int nx) = delete;
 #if defined(__HIP__)
   __host__
 #endif
-  FFT1D_C2R(const int nx, const int batch) = delete;
+  FFT1DC2R(const int nx, const int batch) = delete;
 #if defined(__HIP__)
   __host__
 #endif
-  FFT1D_C2R(const int nx, const int batch, long long inembed,
-            long long ouembed) = delete;
+  FFT1DC2R(const int nx, const int batch, long long inembed,
+           long long ouembed) = delete;
 };
 
 template <>
-FFT1D_C2R<CUDA_C_32F>::FFT1D_C2R(const int nx, const int batch,
-                                 long long inembed, long long ouembed) {
+FFT1DC2R<CUDA_C_32F>::FFT1DC2R(const int nx, const int batch, long long inembed,
+                               long long ouembed) {
   checkCuFFTCall(cufftCreate(plan()));
   const int rank = 1;
   size_t ws = 0;

--- a/include/cudawrappers/cufft.hpp
+++ b/include/cudawrappers/cufft.hpp
@@ -226,7 +226,7 @@ template <>
 FFT2D<CUDA_C_16F>::FFT2D(int nx, int ny) : FFT2D(nx, ny, 1, nx * ny, 1) {}
 
 /*
- * FFT1DRealToComplex
+ * FFT2DRealToComplex
  */
 template <cudaDataType_t T>
 class FFT1DRealToComplex : public FFT {
@@ -240,26 +240,29 @@ class FFT1DRealToComplex : public FFT {
 #endif
   FFT1DRealToComplex(int nx, int batch) = delete;
 
+#if defined(__HIP__)
+  __host__
+#endif
   FFT1DRealToComplex(int nx, int batch, long long inembed,
                      long long ouembed) = delete;
 };
 
 template <>
 FFT1DRealToComplex<CUDA_R_32F>::FFT1DRealToComplex(int nx, int batch,
-                                                   long long inembed,
-                                                   long long ouembed) {
+                                                   long long int inembed,
+                                                   long long int ouembed) {
   checkCuFFTCall(cufftCreate(plan()));
   const int rank = 1;
   size_t ws = 0;
   std::array<long long, 1> n{nx};
-  const long long int idist = inembed;
-  const long long int odist = ouembed;
-
+  long long int idist = inembed;
+  long long int odist = ouembed;
   int istride = 1;
   int ostride = 1;
+
   checkCuFFTCall(cufftXtMakePlanMany(
       *plan(), rank, n.data(), &inembed, istride, idist, CUDA_R_32F, &ouembed,
-      ostride, odist, CUDA_C_32F, batch, &ws, CUDA_R_32F));
+      ostride, odist, CUDA_C_32F, batch, &ws, CUDA_C_32F));
 }
 
 /*
@@ -269,7 +272,6 @@ template <cudaDataType_t T>
 class FFT1DComplexToReal : public FFT {
  public:
 #if defined(__HIP__)
-
   __host__
 #endif
   FFT1DComplexToReal(int nx) = delete;
@@ -277,14 +279,17 @@ class FFT1DComplexToReal : public FFT {
   __host__
 #endif
   FFT1DComplexToReal(int nx, int batch) = delete;
+#if defined(__HIP__)
+  __host__
+#endif
   FFT1DComplexToReal(int nx, int batch, long long inembed,
                      long long ouembed) = delete;
 };
 
 template <>
 FFT1DComplexToReal<CUDA_C_32F>::FFT1DComplexToReal(int nx, int batch,
-                                                   long long inembed,
-                                                   long long ouembed) {
+                                                   long long int inembed,
+                                                   long long int ouembed) {
   checkCuFFTCall(cufftCreate(plan()));
   const int rank = 1;
   size_t ws = 0;
@@ -293,6 +298,7 @@ FFT1DComplexToReal<CUDA_C_32F>::FFT1DComplexToReal(int nx, int batch,
   long long int odist = ouembed;
   int istride = 1;
   int ostride = 1;
+
   checkCuFFTCall(cufftXtMakePlanMany(
       *plan(), rank, n.data(), &inembed, istride, idist, CUDA_C_32F, &ouembed,
       ostride, odist, CUDA_R_32F, batch, &ws, CUDA_C_32F));

--- a/include/cudawrappers/cufft.hpp
+++ b/include/cudawrappers/cufft.hpp
@@ -111,18 +111,19 @@ class FFT {
 
   ~FFT() { checkCuFFTCall(cufftDestroy(plan_)); }
 
-  void setStream(cu::Stream &stream) {
+  void setStream(cu::Stream &stream) const {
     checkCuFFTCall(cufftSetStream(plan_, stream));
   }
 
-  void execute(cu::DeviceMemory &in, cu::DeviceMemory &out, int direction) {
+  void execute(cu::DeviceMemory &in, cu::DeviceMemory &out,
+               const int direction) const {
     void *in_ptr = reinterpret_cast<void *>(static_cast<CUdeviceptr>(in));
     void *out_ptr = reinterpret_cast<void *>(static_cast<CUdeviceptr>(out));
     checkCuFFTCall(cufftXtExec(plan_, in_ptr, out_ptr, direction));
   }
 
  protected:
-  void checkCuFFTCall(cufftResult result) {
+  void checkCuFFTCall(cufftResult result) const {
     if (result != CUFFT_SUCCESS) {
       throw Error(result);
     }
@@ -143,39 +144,39 @@ class FFT1D : public FFT {
 #if defined(__HIP__)
   __host__
 #endif
-  FFT1D(int nx) = delete;
+  FFT1D(const int nx) = delete;
 #if defined(__HIP__)
   __host__
 #endif
-  FFT1D(int nx, int batch) = delete;
+  FFT1D(const int nx, const int batch) = delete;
 };
 
 template <>
-FFT1D<CUDA_C_32F>::FFT1D(int nx, int batch) {
+FFT1D<CUDA_C_32F>::FFT1D(const int nx, const int batch) {
   checkCuFFTCall(cufftCreate(plan()));
   checkCuFFTCall(cufftPlan1d(plan(), nx, CUFFT_C2C, batch));
 }
 
 template <>
-FFT1D<CUDA_C_32F>::FFT1D(int nx) : FFT1D(nx, 1) {}
+FFT1D<CUDA_C_32F>::FFT1D(const int nx) : FFT1D(nx, 1) {}
 
 template <>
-FFT1D<CUDA_C_16F>::FFT1D(int nx, int batch) {
+FFT1D<CUDA_C_16F>::FFT1D(const int nx, const int batch) {
   checkCuFFTCall(cufftCreate(plan()));
   const int rank = 1;
   size_t ws = 0;
   std::array<long long, 1> n{nx};
-  long long int idist = 1;
-  long long int odist = 1;
-  int istride = 1;
-  int ostride = 1;
+  const long long idist = 1;
+  const long long odist = 1;
+  const int istride = 1;
+  const int ostride = 1;
   checkCuFFTCall(cufftXtMakePlanMany(*plan(), rank, n.data(), nullptr, istride,
                                      idist, CUDA_C_16F, nullptr, ostride, odist,
                                      CUDA_C_16F, batch, &ws, CUDA_C_16F));
 }
 
 template <>
-FFT1D<CUDA_C_16F>::FFT1D(int nx) : FFT1D(nx, 1) {}
+FFT1D<CUDA_C_16F>::FFT1D(const int nx) : FFT1D(nx, 1) {}
 
 /*
  * FFT2D
@@ -186,21 +187,23 @@ class FFT2D : public FFT {
 #if defined(__HIP__)
   __host__
 #endif
-  FFT2D(int nx, int ny) = delete;
+  FFT2D(const int nx, const int ny) = delete;
 #if defined(__HIP__)
   __host__
 #endif
-  FFT2D(int nx, int ny, int stride, int dist, int batch) = delete;
+  FFT2D(const int nx, const int ny, const int stride, const int dist,
+        const int batch) = delete;
 };
 
 template <>
-FFT2D<CUDA_C_32F>::FFT2D(int nx, int ny) {
+FFT2D<CUDA_C_32F>::FFT2D(const int nx, const int ny) {
   checkCuFFTCall(cufftCreate(plan()));
   checkCuFFTCall(cufftPlan2d(plan(), nx, ny, CUFFT_C2C));
 }
 
 template <>
-FFT2D<CUDA_C_32F>::FFT2D(int nx, int ny, int stride, int dist, int batch) {
+FFT2D<CUDA_C_32F>::FFT2D(const int nx, const int ny, const int stride,
+                         const int dist, const int batch) {
   checkCuFFTCall(cufftCreate(plan()));
   std::array<int, 2> n{nx, ny};
   checkCuFFTCall(cufftPlanMany(plan(), 2, n.data(), n.data(), stride, dist,
@@ -208,57 +211,58 @@ FFT2D<CUDA_C_32F>::FFT2D(int nx, int ny, int stride, int dist, int batch) {
 }
 
 template <>
-FFT2D<CUDA_C_16F>::FFT2D(int nx, int ny, int stride, int dist, int batch) {
+FFT2D<CUDA_C_16F>::FFT2D(const int nx, const int ny, const int stride,
+                         const int dist, const int batch) {
   checkCuFFTCall(cufftCreate(plan()));
   const int rank = 2;
   size_t ws = 0;
   std::array<long long, 2> n{nx, ny};
-  int istride = stride;
-  int ostride = stride;
-  long long int idist = dist;
-  long long int odist = dist;
+  const int istride = stride;
+  const int ostride = stride;
+  const long long int idist = dist;
+  const long long int odist = dist;
   checkCuFFTCall(cufftXtMakePlanMany(*plan(), rank, n.data(), nullptr, istride,
                                      idist, CUDA_C_16F, nullptr, ostride, odist,
                                      CUDA_C_16F, batch, &ws, CUDA_C_16F));
 }
 
 template <>
-FFT2D<CUDA_C_16F>::FFT2D(int nx, int ny) : FFT2D(nx, ny, 1, nx * ny, 1) {}
+FFT2D<CUDA_C_16F>::FFT2D(const int nx, const int ny)
+    : FFT2D(nx, ny, 1, nx * ny, 1) {}
 
 /*
- * FFT2DRealToComplex
+ * FFT1D_R2C
  */
 template <cudaDataType_t T>
-class FFT1DRealToComplex : public FFT {
+class FFT1D_R2C : public FFT {
  public:
 #if defined(__HIP__)
   __host__
 #endif
-  FFT1DRealToComplex(int nx) = delete;
+  FFT1D_R2C(const int nx) = delete;
 #if defined(__HIP__)
   __host__
 #endif
-  FFT1DRealToComplex(int nx, int batch) = delete;
+  FFT1D_R2C(const int nx, const int batch) = delete;
 
 #if defined(__HIP__)
   __host__
 #endif
-  FFT1DRealToComplex(int nx, int batch, long long inembed,
-                     long long ouembed) = delete;
+  FFT1D_R2C(const int nx, const int batch, long long inembed,
+            long long ouembed) = delete;
 };
 
 template <>
-FFT1DRealToComplex<CUDA_R_32F>::FFT1DRealToComplex(int nx, int batch,
-                                                   long long int inembed,
-                                                   long long int ouembed) {
+FFT1D_R2C<CUDA_R_32F>::FFT1D_R2C(const int nx, const int batch,
+                                 long long inembed, long long ouembed) {
   checkCuFFTCall(cufftCreate(plan()));
   const int rank = 1;
   size_t ws = 0;
   std::array<long long, 1> n{nx};
-  long long int idist = inembed;
-  long long int odist = ouembed;
-  int istride = 1;
-  int ostride = 1;
+  const long long idist = inembed;
+  const long long odist = ouembed;
+  const long long istride = 1;
+  const long long ostride = 1;
 
   checkCuFFTCall(cufftXtMakePlanMany(
       *plan(), rank, n.data(), &inembed, istride, idist, CUDA_R_32F, &ouembed,
@@ -266,38 +270,37 @@ FFT1DRealToComplex<CUDA_R_32F>::FFT1DRealToComplex(int nx, int batch,
 }
 
 /*
- * FFT1DComplexToReal
+ * FFT1D_C2R
  */
 template <cudaDataType_t T>
-class FFT1DComplexToReal : public FFT {
+class FFT1D_C2R : public FFT {
  public:
 #if defined(__HIP__)
   __host__
 #endif
-  FFT1DComplexToReal(int nx) = delete;
+  FFT1D_C2R(const int nx) = delete;
 #if defined(__HIP__)
   __host__
 #endif
-  FFT1DComplexToReal(int nx, int batch) = delete;
+  FFT1D_C2R(const int nx, const int batch) = delete;
 #if defined(__HIP__)
   __host__
 #endif
-  FFT1DComplexToReal(int nx, int batch, long long inembed,
-                     long long ouembed) = delete;
+  FFT1D_C2R(const int nx, const int batch, long long inembed,
+            long long ouembed) = delete;
 };
 
 template <>
-FFT1DComplexToReal<CUDA_C_32F>::FFT1DComplexToReal(int nx, int batch,
-                                                   long long int inembed,
-                                                   long long int ouembed) {
+FFT1D_C2R<CUDA_C_32F>::FFT1D_C2R(const int nx, const int batch,
+                                 long long inembed, long long ouembed) {
   checkCuFFTCall(cufftCreate(plan()));
   const int rank = 1;
   size_t ws = 0;
   std::array<long long, 1> n{nx};
-  long long int idist = inembed;
-  long long int odist = ouembed;
-  int istride = 1;
-  int ostride = 1;
+  const long long idist = inembed;
+  const long long odist = ouembed;
+  const int istride = 1;
+  const int ostride = 1;
 
   checkCuFFTCall(cufftXtMakePlanMany(
       *plan(), rank, n.data(), &inembed, istride, idist, CUDA_C_32F, &ouembed,

--- a/include/cudawrappers/cufft.hpp
+++ b/include/cudawrappers/cufft.hpp
@@ -11,8 +11,8 @@
 #include <cufftXt.h>
 #endif
 
-#include <exception>
 #include <array>
+#include <exception>
 
 #include "cudawrappers/cu.hpp"
 
@@ -240,23 +240,26 @@ class FFT1DRealToComplex : public FFT {
 #endif
   FFT1DRealToComplex(int nx, int batch) = delete;
 
-  FFT1DRealToComplex(int nx, int batch, std::array<long long, 1>& inembed, std::array<long long, 1>& ouembed) = delete;
+  FFT1DRealToComplex(int nx, int batch, long long inembed,
+                     long long ouembed) = delete;
 };
 
-
 template <>
-FFT1DRealToComplex<CUDA_R_32F>::FFT1DRealToComplex(int nx, int batch, std::array<long long, 1>& inembed, std::array<long long, 1>& ouembed) {
+FFT1DRealToComplex<CUDA_R_32F>::FFT1DRealToComplex(int nx, int batch,
+                                                   long long inembed,
+                                                   long long ouembed) {
   checkCuFFTCall(cufftCreate(plan()));
   const int rank = 1;
   size_t ws = 0;
   std::array<long long, 1> n{nx};
-  long long int idist = inembed[0];
-  long long int odist = ouembed[0];
+  const long long int idist = inembed;
+  const long long int odist = ouembed;
+
   int istride = 1;
   int ostride = 1;
-  checkCuFFTCall(cufftXtMakePlanMany(*plan(), rank, n.data(), inembed.data(), istride,
-                                     idist, CUDA_R_32F, ouembed.data(), ostride, odist,
-                                     CUDA_C_32F, batch, &ws, CUDA_R_32F));
+  checkCuFFTCall(cufftXtMakePlanMany(
+      *plan(), rank, n.data(), &inembed, istride, idist, CUDA_R_32F, &ouembed,
+      ostride, odist, CUDA_C_32F, batch, &ws, CUDA_R_32F));
 }
 
 /*
@@ -266,6 +269,7 @@ template <cudaDataType_t T>
 class FFT1DComplexToReal : public FFT {
  public:
 #if defined(__HIP__)
+
   __host__
 #endif
   FFT1DComplexToReal(int nx) = delete;
@@ -273,30 +277,27 @@ class FFT1DComplexToReal : public FFT {
   __host__
 #endif
   FFT1DComplexToReal(int nx, int batch) = delete;
-
-  FFT1DComplexToReal(int nx, int batch, std::array<long long, 1>& inembed, std::array<long long, 1>& ouembed) = delete;
+  FFT1DComplexToReal(int nx, int batch, long long inembed,
+                     long long ouembed) = delete;
 };
 
-
 template <>
-FFT1DComplexToReal<CUDA_C_32F>::FFT1DComplexToReal(int nx, int batch, std::array<long long, 1>& inembed, std::array<long long, 1>& ouembed) {
+FFT1DComplexToReal<CUDA_C_32F>::FFT1DComplexToReal(int nx, int batch,
+                                                   long long inembed,
+                                                   long long ouembed) {
   checkCuFFTCall(cufftCreate(plan()));
   const int rank = 1;
   size_t ws = 0;
   std::array<long long, 1> n{nx};
-  long long int idist = inembed[0];
-  long long int odist = ouembed[0];
+  long long int idist = inembed;
+  long long int odist = ouembed;
   int istride = 1;
   int ostride = 1;
-  checkCuFFTCall(cufftXtMakePlanMany(*plan(), rank, n.data(), inembed.data(), istride,
-                                     idist, CUDA_C_32F, ouembed.data(), ostride, odist,
-                                     CUDA_R_32F, batch, &ws, CUDA_C_32F));
+  checkCuFFTCall(cufftXtMakePlanMany(
+      *plan(), rank, n.data(), &inembed, istride, idist, CUDA_C_32F, &ouembed,
+      ostride, odist, CUDA_R_32F, batch, &ws, CUDA_C_32F));
 }
 
-
 }  // namespace cufft
-
-
-
 
 #endif  // CUFFT_H

--- a/include/cudawrappers/nvtx.hpp
+++ b/include/cudawrappers/nvtx.hpp
@@ -1,7 +1,9 @@
 #if !defined NVTX_H
 #define NVTX_H
 
+#if !defined(__HIP__)
 #include <nvToolsExt.h>
+#endif
 
 namespace nvtx {
 
@@ -9,6 +11,10 @@ class Marker {
  public:
   enum Color { red, green, blue, yellow, black };
 
+#if defined(__HIP__)
+  explicit Marker(const char* message, unsigned color = Color::green) {}
+
+#else
   explicit Marker(const char* message, unsigned color = Color::green)
       : _attributes{0} {
     _attributes.version = NVTX_VERSION;
@@ -18,12 +24,21 @@ class Marker {
     _attributes.messageType = NVTX_MESSAGE_TYPE_ASCII;
     _attributes.message.ascii = message;
   }
+#endif
 
   Marker(const char* message, Color color) : Marker(message, convert(color)) {}
 
-  void start() { _id = nvtxRangeStartEx(&_attributes); }
+  void start() {
+#if !defined(__HIP__)
+    _id = nvtxRangeStartEx(&_attributes);
+#endif
+  }
 
-  void end() { nvtxRangeEnd(_id); }
+  void end() {
+#if !defined(__HIP__)
+    nvtxRangeEnd(_id);
+#endif
+  }
 
  private:
   unsigned int convert(Color color) {
@@ -43,8 +58,10 @@ class Marker {
     }
   }
 
+#if !defined(__HIP__)
   nvtxEventAttributes_t _attributes;
   nvtxRangeId_t _id;
+#endif
 };
 
 }  // end namespace nvtx

--- a/tests/test_cu.cpp
+++ b/tests/test_cu.cpp
@@ -12,26 +12,26 @@ TEST_CASE("Test cu::Device", "[device]") {
   cu::Device device(0);
   cu::Context context(CU_CTX_SCHED_BLOCKING_SYNC, device);
 
-  SECTION("Test Device.getName") {
+  SECTION("Test Device.getName", "[device]") {
     const std::string name = device.getName();
     std::cout << "Device name: " << name << std::endl;
     CHECK(name.size() > 0);
   }
 
-  SECTION("Test Device.getArch") {
+  SECTION("Test Device.getArch", "[device]") {
     const std::string arch = device.getArch();
     std::cout << "Device arch: " << arch << std::endl;
     CHECK(arch.size() > 0);
   }
 
-  SECTION("Test device::totalMem", "[device]") {
-    const size_t total_mem = device.totalMem();
+  SECTION("Test device.getTotalMem", "[device]") {
+    const size_t total_mem = device.getTotalMem();
     std::cout << "Device total memory: " << (total_mem / (1024 * 1024))
               << " bytes" << std::endl;
     CHECK(total_mem > 0);
   }
 
-  SECTION("Test Device.getTotalConstMem") {
+  SECTION("Test Device.getTotalConstMem", "[device]") {
     const size_t const_mem = device.getTotalConstMem();
     std::cout << "Device constant memory: " << const_mem << " bytes"
               << std::endl;

--- a/tests/test_cu.cpp
+++ b/tests/test_cu.cpp
@@ -221,7 +221,7 @@ TEST_CASE("Test cu::DeviceMemory", "[devicememory]") {
   SECTION("Test cu::DeviceMemory with CU_MEMORYTYPE_DEVICE as host pointer") {
     cu::DeviceMemory mem(sizeof(float), CU_MEMORYTYPE_DEVICE, 0);
     float* ptr;
-    CHECK_NOTHROWS(ptr = mem);
+    CHECK_NOTHROW(ptr = mem);
   }
 
   SECTION("Test cu::DeviceMemory with CU_MEMORYTYPE_UNIFIED as host pointer") {

--- a/tests/test_cu.cpp
+++ b/tests/test_cu.cpp
@@ -37,6 +37,11 @@ TEST_CASE("Test cu::Device", "[device]") {
               << std::endl;
     CHECK(const_mem > 0);
   }
+
+  SECTION("Test Device.getOrdinal", "[device]") {
+    const int dev_ordinal = device.getOrdinal();
+    CHECK(dev_ordinal >= 0);
+  }
 }
 
 TEST_CASE("Test context::getDevice", "[device]") {

--- a/tests/test_cu.cpp
+++ b/tests/test_cu.cpp
@@ -221,7 +221,7 @@ TEST_CASE("Test cu::DeviceMemory", "[devicememory]") {
   SECTION("Test cu::DeviceMemory with CU_MEMORYTYPE_DEVICE as host pointer") {
     cu::DeviceMemory mem(sizeof(float), CU_MEMORYTYPE_DEVICE, 0);
     float* ptr;
-    CHECK_THROWS(ptr = mem);
+    CHECK_NOTHROWS(ptr = mem);
   }
 
   SECTION("Test cu::DeviceMemory with CU_MEMORYTYPE_UNIFIED as host pointer") {

--- a/tests/test_cu.cpp
+++ b/tests/test_cu.cpp
@@ -23,6 +23,20 @@ TEST_CASE("Test cu::Device", "[device]") {
     std::cout << "Device arch: " << arch << std::endl;
     CHECK(arch.size() > 0);
   }
+
+  SECTION("Test Device.totalMem") {
+    const size_t total_mem = device.totalMem();
+    std::cout << "Device total memory: " << (total_mem / (1024 * 1024))
+              << " bytes" << std::endl;
+    CHECK(total_mem > 0);
+  }
+
+  SECTION("Test Device.getTotalConstMem") {
+    const size_t const_mem = device.getTotalConstMem();
+    std::cout << "Device constant memory: " << const_mem << " bytes"
+              << std::endl;
+    CHECK(const_mem > 0);
+  }
 }
 
 TEST_CASE("Test context::getDevice", "[device]") {
@@ -57,6 +71,24 @@ TEST_CASE("Test copying cu::DeviceMemory and cu::HostMemory using cu::Stream",
     CHECK(src == tgt);
   }
 
+  SECTION("Test copying a 2D std::array to the device and back") {
+    const std::array<std::array<int, 3>, 3> src = {
+        {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}};
+    std::array<std::array<int, 3>, 3> tgt = {{{0, 0, 0}, {0, 0, 0}, {0, 0, 0}}};
+    const size_t width = 3 * sizeof(int);
+    const size_t height = 3;
+    const size_t pitch = width;
+
+    cu::DeviceMemory mem(pitch * height);
+
+    cu::Stream stream;
+    stream.memcpyHtoD2DAsync(mem, pitch, src.data(), pitch, width, height);
+    stream.memcpyDtoH2DAsync(tgt.data(), pitch, mem, pitch, width, height);
+    stream.synchronize();
+
+    CHECK(src == tgt);
+  }
+
   SECTION("Test copying HostMemory to the device and back") {
     const size_t N = 3;
     const size_t size = N * sizeof(int);
@@ -78,6 +110,34 @@ TEST_CASE("Test copying cu::DeviceMemory and cu::HostMemory using cu::Stream",
     stream.synchronize();
 
     CHECK(!static_cast<bool>(memcmp(src, tgt, size)));
+  }
+
+  SECTION("Test copying 2D HostMemory to the device and back") {
+    const size_t width = 3 * sizeof(int);
+    const size_t height = 3;
+    const size_t pitch = width;
+    const size_t size = pitch * height;
+    cu::HostMemory src(size);
+    cu::HostMemory tgt(size);
+
+    // Populate the 2D memory with values
+    int* const src_ptr = static_cast<int*>(src);
+    int* const tgt_ptr = static_cast<int*>(tgt);
+    for (int y = 0; y < height; ++y) {
+      for (int x = 0; x < 3; ++x) {
+        src_ptr[y * 3 + x] = y * 3 + x + 1;
+        tgt_ptr[y * 3 + x] = 0;
+      }
+    }
+
+    cu::DeviceMemory mem(size);
+    cu::Stream stream;
+
+    stream.memcpyHtoD2DAsync(mem, pitch, src, pitch, width, height);
+    stream.memcpyDtoH2DAsync(tgt, pitch, mem, pitch, width, height);
+    stream.synchronize();
+
+    CHECK(static_cast<bool>(memcmp(src, tgt, size)) == 0);
   }
 }
 
@@ -206,7 +266,7 @@ TEST_CASE("Test cu::DeviceMemory", "[devicememory]") {
 }
 
 using TestTypes = std::tuple<unsigned char, unsigned short, unsigned int>;
-TEMPLATE_LIST_TEST_CASE("Test memset", "[memset]", TestTypes) {
+TEMPLATE_LIST_TEST_CASE("Test memset 1D", "[memset]", TestTypes) {
   cu::init();
   cu::Device device(0);
   cu::Context context(CU_CTX_SCHED_BLOCKING_SYNC, device);
@@ -257,6 +317,71 @@ TEMPLATE_LIST_TEST_CASE("Test memset", "[memset]", TestTypes) {
     stream.synchronize();
     mem.memset(value, N);
     stream.memcpyDtoHAsync(b, mem, size);
+    stream.synchronize();
+
+    CHECK(static_cast<bool>(memcmp(a, b, size)));
+  }
+}
+
+using TestTypes = std::tuple<unsigned char, unsigned short, unsigned int>;
+TEMPLATE_LIST_TEST_CASE("Test memset 2D", "[memset]", TestTypes) {
+  cu::init();
+  cu::Device device(0);
+  cu::Context context(CU_CTX_SCHED_BLOCKING_SYNC, device);
+
+  SECTION("Test memset2D cu::DeviceMemory asynchronously") {
+    const size_t width = 3;
+    const size_t height = 3;
+    const size_t pitch = width * sizeof(TestType);
+    const size_t size = pitch * height;
+    cu::HostMemory a(size);
+    cu::HostMemory b(size);
+    TestType value = 0xAA;
+
+    // Populate the memory with initial values
+    TestType* const a_ptr = static_cast<TestType*>(a);
+    TestType* const b_ptr = static_cast<TestType*>(b);
+    for (int i = 0; i < width * height; i++) {
+      a_ptr[i] = 0;
+      b_ptr[i] = value;
+    }
+
+    cu::DeviceMemory mem(size);
+    cu::Stream stream;
+
+    // Perform the 2D memory operations
+    stream.memcpyHtoD2DAsync(mem, pitch, b, pitch, width, height);
+    stream.memset2DAsync(mem, value, pitch, width, height);
+    stream.memcpyDtoH2DAsync(b, pitch, mem, pitch, width, height);
+
+    CHECK(static_cast<bool>(memcmp(a, b, size)));
+  }
+
+  SECTION("Test zeroing cu::DeviceMemory synchronously in 2D") {
+    const size_t width = 3;
+    const size_t height = 3;
+    const size_t pitch = width * sizeof(TestType);
+    const size_t size = pitch * height;
+    cu::HostMemory a(size);
+    cu::HostMemory b(size);
+    TestType value = 0xAA;
+
+    // Populate the memory with initial values
+    TestType* const a_ptr = static_cast<TestType*>(a);
+    TestType* const b_ptr = static_cast<TestType*>(b);
+    for (int i = 0; i < width * height; i++) {
+      a_ptr[i] = 0;
+      b_ptr[i] = value;
+    }
+
+    cu::DeviceMemory mem(size);
+    cu::Stream stream;
+
+    // Perform the 2D memory operations
+    stream.memcpyHtoD2DAsync(mem, pitch, b, pitch, width, height);
+    stream.synchronize();
+    mem.memset2D(value, pitch, width, height);
+    stream.memcpyDtoH2DAsync(b, pitch, mem, pitch, width, height);
     stream.synchronize();
 
     CHECK(static_cast<bool>(memcmp(a, b, size)));

--- a/tests/test_cu.cpp
+++ b/tests/test_cu.cpp
@@ -24,18 +24,11 @@ TEST_CASE("Test cu::Device", "[device]") {
     CHECK(arch.size() > 0);
   }
 
-  SECTION("Test device.getTotalMem", "[device]") {
-    const size_t total_mem = device.getTotalMem();
+  SECTION("Test device.totalMem", "[device]") {
+    const size_t total_mem = device.totalMem();
     std::cout << "Device total memory: " << (total_mem / (1024 * 1024))
               << " bytes" << std::endl;
     CHECK(total_mem > 0);
-  }
-
-  SECTION("Test Device.getTotalConstMem", "[device]") {
-    const size_t const_mem = device.getTotalConstMem();
-    std::cout << "Device constant memory: " << const_mem << " bytes"
-              << std::endl;
-    CHECK(const_mem > 0);
   }
 
   SECTION("Test Device.getOrdinal", "[device]") {

--- a/tests/test_cu.cpp
+++ b/tests/test_cu.cpp
@@ -24,7 +24,7 @@ TEST_CASE("Test cu::Device", "[device]") {
     CHECK(arch.size() > 0);
   }
 
-  SECTION("Test Device.totalMem") {
+  SECTION("Test device::totalMem", "[device]") {
     const size_t total_mem = device.totalMem();
     std::cout << "Device total memory: " << (total_mem / (1024 * 1024))
               << " bytes" << std::endl;

--- a/tests/test_cufft.cpp
+++ b/tests/test_cufft.cpp
@@ -115,7 +115,7 @@ TEST_CASE("Test 1D FFT", "[FFT1D]") {
     compare(out_ptr, in_ptr, size);
   }
 
-  SECTION("FP32 R2C C2R") {
+  SECTION("FP32 FFT with Real-To-Complex translation, and back") {
     const size_t arraySize = size * sizeof(cufftComplex);
 
     cu::HostMemory h_in(arraySize);
@@ -127,8 +127,8 @@ TEST_CASE("Test 1D FFT", "[FFT1D]") {
     generateSignal(static_cast<cufftComplex *>(h_in), size, patchSize, {1, 1});
     stream.memcpyHtoDAsync(d_in, h_in, arraySize);
 
-    cufft::FFT1DRealToComplex<CUDA_R_32F> fft_r2c(size, 1, 1, 1);
-    cufft::FFT1DComplexToReal<CUDA_C_32F> fft_c2r(size, 1, 1, 1);
+    cufft::FFT1D_R2C<CUDA_R_32F> fft_r2c(size, 1, 1, 1);
+    cufft::FFT1D_C2R<CUDA_C_32F> fft_c2r(size, 1, 1, 1);
     fft_r2c.setStream(stream);
     fft_c2r.setStream(stream);
 

--- a/tests/test_cufft.cpp
+++ b/tests/test_cufft.cpp
@@ -127,8 +127,8 @@ TEST_CASE("Test 1D FFT", "[FFT1D]") {
     generateSignal(static_cast<cufftComplex *>(h_in), size, patchSize, {1, 1});
     stream.memcpyHtoDAsync(d_in, h_in, arraySize);
 
-    cufft::FFT1D_R2C<CUDA_R_32F> fft_r2c(size, 1, 1, 1);
-    cufft::FFT1D_C2R<CUDA_C_32F> fft_c2r(size, 1, 1, 1);
+    cufft::FFT1DR2C<CUDA_R_32F> fft_r2c(size, 1, 1, 1);
+    cufft::FFT1DC2R<CUDA_C_32F> fft_c2r(size, 1, 1, 1);
     fft_r2c.setStream(stream);
     fft_c2r.setStream(stream);
 


### PR DESCRIPTION
**Description**

This pull request includes support for various 2D operations, namely `memset2D`, `memcpyHtoD2DAsync`, `memcpyDtoH2DAsync,` and introduces `FFT1DRealToComplex` and `FFT1DComplexToReal` classes for FFT transformations. Finally, the `cu::Device::getOrdinal()` method is introduced to retrieve the current device ID.
Related tests are included in this pull request.

**Related issues**:

None

**Instructions to review the pull request**

- Check that CHANGELOG.md has been updated if necessary

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```
-->

<!--
Review online.
-->
