### PR TITLE
Update nvml interface

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,7 @@ repos:
           - '--suppress=unreadVariable:tests/*'
           - '--suppress=missingIncludeSystem'
           - '--suppress=unmatchedSuppression'
+        pass_filenames: false
   - repo: https://github.com/cheshirekow/cmake-format-precommit
     rev: v0.6.13
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - `target_embed_source` is now more robust: it properly tracks dependencies and
   runs again whenever any of them changes
 - Expanded tests to cover the new 2D memory operations and FFT support
+- Removed the `context` from `nvml::Device` constructors
 
 ## \[0.8.0\] - 2024-07-05
 

--- a/include/cudawrappers/nvml.hpp
+++ b/include/cudawrappers/nvml.hpp
@@ -35,11 +35,11 @@ class Context {
 
 class Device {
  public:
-  Device(Context& context, int index) {
+  Device(int index) {
     checkNvmlCall(nvmlDeviceGetHandleByIndex(index, &device_));
   }
 
-  Device(Context& context, cu::Device& device) {
+  Device(cu::Device& device) {
     const std::string uuid = device.getUuid();
     nvmlDeviceGetHandleByUUID(uuid.c_str(), &device_);
   }

--- a/include/cudawrappers/nvml.hpp
+++ b/include/cudawrappers/nvml.hpp
@@ -41,7 +41,7 @@ class Device {
 
   Device(cu::Device& device) {
     const std::string uuid = device.getUuid();
-    nvmlDeviceGetHandleByUUID(uuid.c_str(), &device_);
+    checkNvmlCall(nvmlDeviceGetHandleByUUID(uuid.c_str(), &device_));
   }
 
   void getFieldValues(int valuesCount, nvmlFieldValue_t* values) {

--- a/include/cudawrappers/nvml.hpp
+++ b/include/cudawrappers/nvml.hpp
@@ -44,17 +44,18 @@ class Device {
     checkNvmlCall(nvmlDeviceGetHandleByUUID(uuid.c_str(), &device_));
   }
 
-  void getFieldValues(int valuesCount, nvmlFieldValue_t* values) {
+  void getFieldValues(int valuesCount, nvmlFieldValue_t* values) const {
     checkNvmlCall(nvmlDeviceGetFieldValues(device_, valuesCount, values));
   }
 
-  unsigned int getClock(nvmlClockType_t clockType, nvmlClockId_t clockId) {
+  unsigned int getClock(nvmlClockType_t clockType,
+                        nvmlClockId_t clockId) const {
     unsigned int clockMhz;
     checkNvmlCall(nvmlDeviceGetClock(device_, clockType, clockId, &clockMhz));
     return clockMhz;
   }
 
-  unsigned int getPower() {
+  unsigned int getPower() const {
     unsigned int power;
     checkNvmlCall(nvmlDeviceGetPowerUsage(device_, &power));
     return power;

--- a/tests/test_nvml.cpp
+++ b/tests/test_nvml.cpp
@@ -9,12 +9,12 @@ TEST_CASE("Test nvml::Context", "[context]") { nvml::Context context; }
 
 TEST_CASE("Test nvml::Device with device number", "[device]") {
   nvml::Context context;
-  nvml::Device device(context, 0);
+  nvml::Device device(0);
 }
 
 TEST_CASE("Test nvml::Device::getClock", "[device]") {
   nvml::Context context;
-  nvml::Device device(context, 0);
+  nvml::Device device(0);
   const unsigned int clockMHz =
       device.getClock(NVML_CLOCK_GRAPHICS, NVML_CLOCK_ID_CURRENT);
   REQUIRE(clockMHz > 0);
@@ -22,7 +22,7 @@ TEST_CASE("Test nvml::Device::getClock", "[device]") {
 
 TEST_CASE("Test nvml::Device::getPower", "[device]") {
   nvml::Context context;
-  nvml::Device device(context, 0);
+  nvml::Device device(0);
   const unsigned int power = device.getPower();
   REQUIRE(power > 0);
 }
@@ -31,5 +31,5 @@ TEST_CASE("Test nvml::Device with device", "[device]") {
   cu::init();
   cu::Device cu_device(0);
   nvml::Context nvml_context;
-  nvml::Device nvml_device(nvml_context, cu_device);
+  nvml::Device nvml_device(cu_device);
 }


### PR DESCRIPTION
**Description**

* Remove the unused `context` argument from the `nvml::Device` constructor
* Make `nvml::Device` functions `const`
* Add missing `checkNvmlCall`

**Related issues**:

N.A.

**Instructions to review the pull request**

- Check that CHANGELOG.md has been updated if necessary

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```
-->

<!--
Review online.
-->
