### PR TITLE
Update cuda-Jimver/toolkit to v0.2.19

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     name: run
     runs-on: ubuntu-22.04
     env:
-        cuda-version: "12.2.0"
+        cuda-version: "12.6.1"
         hip-version: "6.1.3"
         amdgpu-version: "6.1.60103-1_all"
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
           echo "GITHUB_REF_NAME = $GITHUB_REF_NAME"
 
       - name: Install cuda
-        uses: Jimver/cuda-toolkit@v0.2.11
+        uses: Jimver/cuda-toolkit@v0.2.19
         with:
           cuda: ${{ env.cuda-version }}
           method: "network"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,7 +14,7 @@ jobs:
         # clang defaults to v14.0.0
         gcc-version: "12"  # = 12.1.0
         # cuda version to install with separate action
-        cuda-version: "12.2.0"
+        cuda-version: "12.6.1"
         # version for cmake-lint and cmake-format
         clang-format-version: "v18.1.4"
         cmake-format-version: "v0.6.13"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -54,7 +54,7 @@ jobs:
           git checkout ${{ env.precommit_to_ref }}
 
       - name: Install cuda
-        uses: Jimver/cuda-toolkit@v0.2.11
+        uses: Jimver/cuda-toolkit@v0.2.19
         with:
           cuda: ${{ env.cuda-version }}
           method: "network"

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - clang-tools==14.0.0
   - cmake>=3.17
   - cppcheck==2.7.5
-  - cudatoolkit-dev==12.2.0
+  - cudatoolkit-dev==12.6.1
   - cxx-compiler
   - doxygen
   - gcovr


### PR DESCRIPTION
**Description**

The CI seems broken, updating to the most recent cuda-toolkit may fix it.

**Related issues**:

N.A.

**Instructions to review the pull request**

- Check that CHANGELOG.md has been updated if necessary

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```
-->

<!--
Review online.
-->
