### PR TITLE
Add deprecated message to cu::Context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Added `cu::DeviceMemory::memset2D()` and `cu::Stream::memset2DAsync()`
 - Added `cufft::FFT1DR2C` and `cufft::FFT1DC2R`
 - Added `cu::Device::getOrdinal()`
+- Added deprecated warning to `cu::Context` constructor
 
 ### Changed
 

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -243,7 +243,9 @@ class Context : public Wrapper<CUcontext> {
  public:
   // Context Management
 
-  Context(int flags, Device &device) : _primaryContext(false), _device(device) {
+  [[deprecated("Context is deprecated since cudawrappers v0.9.0.")]]
+  Context(int flags, Device &device)
+      : _primaryContext(false), _device(device) {
 #if !defined(__HIP__)
     checkCudaCall(cuCtxCreate(&_obj, flags, device));
     manager =

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -243,7 +243,7 @@ class Context : public Wrapper<CUcontext> {
  public:
   // Context Management
 
-  [[deprecated("Context is deprecated since cudawrappers v0.9.0.")]]
+  [[deprecated("cu::Context is deprecated since cudawrappers version 0.9.0.")]]
   Context(int flags, Device &device)
       : _primaryContext(false), _device(device) {
 #if !defined(__HIP__)


### PR DESCRIPTION
Since contexts are deprecated in HIP, their use should be discouraged. This pull request introduces a deprecated message when instantiating a `cu::Context` instance.  In a future version of cudawrappers, we plan to remove `cu::Context` entirely (see issue #313). 
