### PR TITLE
Remove Primary Context functiions from cu::Device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - `target_embed_source` is now more robust: it properly tracks dependencies and
   runs again whenever any of them changes
 - Expanded tests to cover the new 2D memory operations and FFT support
+
+### Removed
+
 - Removed the `context` from `nvml::Device` constructors
 
 ## \[0.8.0\] - 2024-07-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 - Removed the `context` from `nvml::Device` constructors
+- Removed the Primary Context related functions from `cu::Device`
 
 ## \[0.8.0\] - 2024-07-05
 

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -207,34 +207,6 @@ class Device : public Wrapper<CUdevice> {
 
   int getOrdinal() const { return _ordinal; }
 
-  // Primary Context Management
-  std::pair<unsigned, bool> primaryCtxGetState() const {
-    unsigned flags{};
-    int active{};
-#if !defined(__HIP__)
-    checkCudaCall(cuDevicePrimaryCtxGetState(_obj, &flags, &active));
-#endif
-    return {flags, active};
-  }
-
-  // void primaryCtxRelease() not available; it is released on destruction of
-  // the Context returned by Device::primaryContextRetain()
-
-  void primaryCtxReset() {
-#if !defined(__HIP__)
-    checkCudaCall(cuDevicePrimaryCtxReset(_obj));
-#endif
-  }
-
-  Context primaryCtxRetain();  // retain this context until the primary context
-                               // can be released
-
-  void primaryCtxSetFlags(unsigned flags) {
-#if !defined(__HIP__)
-    checkCudaCall(cuDevicePrimaryCtxSetFlags(_obj, flags));
-#endif
-  }
-
  private:
   int _ordinal;
 };

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -217,7 +217,7 @@ class Context : public Wrapper<CUcontext> {
 
   [[deprecated("cu::Context is deprecated since cudawrappers version 0.9.0.")]]
   Context(int flags, Device &device)
-      : _primaryContext(false), _device(device) {
+      : _device(device) {
 #if !defined(__HIP__)
     checkCudaCall(cuCtxCreate(&_obj, flags, device));
     manager =
@@ -331,9 +331,8 @@ class Context : public Wrapper<CUcontext> {
  private:
   friend class Device;
   Context(CUcontext context, Device &device)
-      : Wrapper<CUcontext>(context), _primaryContext(true), _device(device) {}
+      : Wrapper<CUcontext>(context), _device(device) {}
 
-  bool _primaryContext;
   cu::Device &_device;
 };
 


### PR DESCRIPTION
**Description**

As discussed in https://github.com/nlesc-recruit/cudawrappers/issues/306#issuecomment-2631466079, the CUDA Context related code should be removed from the user interface. This PR removes all the Primary Context related functions from the `cu::Device` class. The `_primaryContext` in the `cu::Context` class was not used and is also removed.

**Related issues**:

- https://github.com/nlesc-recruit/cudawrappers/issues/306
- https://github.com/nlesc-recruit/cudawrappers/issues/313
- https://github.com/nlesc-recruit/cudawrappers/issues/292

**Instructions to review the pull request**

- Check that CHANGELOG.md has been updated if necessary

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```
-->

<!--
Review online.
-->
