### PR TITLE
Remove cu::Context class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Added `cu::DeviceMemory::memset2D()` and `cu::Stream::memset2DAsync()`
 - Added `cufft::FFT1DR2C` and `cufft::FFT1DC2R`
 - Added `cu::Device::getOrdinal()`
-- Added deprecated warning to `cu::Context` constructor
 
 ### Changed
 
@@ -36,6 +35,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 - Removed the `context` from `nvml::Device` constructors
 - Removed the Primary Context related functions from `cu::Device`
+- Remove the `cu::Context` class
 
 ## \[0.8.0\] - 2024-07-05
 

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -53,6 +53,20 @@ inline int driverGetVersion() {
   return version;
 }
 
+size_t getFreeMemory() {
+  size_t free;
+  size_t total;
+  checkCudaCall(cuMemGetInfo(&free, &total));
+  return free;
+}
+
+size_t getTotalMemory() {
+  size_t free;
+  size_t total;
+  checkCudaCall(cuMemGetInfo(&free, &total));
+  return total;
+}
+
 inline void memcpyHtoD(CUdeviceptr dst, const void *src, size_t size) {
 #if defined(__HIP__)
   // const_cast is a temp fix for https://github.com/ROCm/ROCm/issues/2977
@@ -121,6 +135,16 @@ class Device : public Wrapper<CUdevice> {
 
   explicit Device(int ordinal) : _ordinal(ordinal) {
     checkCudaCall(cuDeviceGet(&_obj, ordinal));
+#if !defined(__HIP__)
+    unsigned int flags;
+    int active;
+    checkCudaCall(cuDevicePrimaryCtxGetState(_obj, &flags, &active));
+    if (active) {
+      checkCudaCall(cuDevicePrimaryCtxRetain(&_pctx, _obj));
+    } else {
+      checkCudaCall(cuCtxCreate(&_pctx, flags, _obj));
+    }
+#endif
   }
 
   struct CUdeviceArg {
@@ -208,132 +232,10 @@ class Device : public Wrapper<CUdevice> {
   int getOrdinal() const { return _ordinal; }
 
  private:
+#if !defined(__HIP__)
+  CUcontext _pctx;
+#endif
   int _ordinal;
-};
-
-class Context : public Wrapper<CUcontext> {
- public:
-  // Context Management
-
-  [[deprecated("cu::Context is deprecated since cudawrappers version 0.9.0.")]]
-  Context(int flags, Device &device)
-      : _device(device) {
-#if !defined(__HIP__)
-    checkCudaCall(cuCtxCreate(&_obj, flags, device));
-    manager =
-        std::shared_ptr<CUcontext>(new CUcontext(_obj), [](CUcontext *ptr) {
-          if (*ptr) cuCtxDestroy(*ptr);
-          delete ptr;
-        });
-#endif
-  }
-
-  unsigned getApiVersion() const {
-    unsigned version{};
-#if !defined(__HIP__)
-    checkCudaCall(cuCtxGetApiVersion(_obj, &version));
-#endif
-    return version;
-  }
-
-  static CUfunc_cache getCacheConfig() {
-    CUfunc_cache config{};
-#if !defined(__HIP__)
-    checkCudaCall(cuCtxGetCacheConfig(&config));
-#endif
-    return config;
-  }
-
-  static void setCacheConfig(CUfunc_cache config) {
-#if !defined(__HIP__)
-    checkCudaCall(cuCtxSetCacheConfig(config));
-#endif
-  }
-
-  Context getCurrent() {
-    CUcontext context{};
-#if !defined(__HIP__)
-    checkCudaCall(cuCtxGetCurrent(&context));
-#endif
-    return Context(context, _device);
-  }
-
-  void setCurrent() const {
-#if !defined(__HIP__)
-    checkCudaCall(cuCtxSetCurrent(_obj));
-#endif
-  }
-
-  Context popCurrent() {
-    CUcontext context{};
-#if !defined(__HIP__)
-    checkCudaCall(cuCtxPopCurrent(&context));
-#endif
-    return Context(context, _device);
-  }
-
-  void pushCurrent() {
-#if !defined(__HIP__)
-    checkCudaCall(cuCtxPushCurrent(_obj));
-#endif
-  }
-
-  Device getDevice() {
-    CUdevice device;
-#if !defined(__HIP__)
-    checkCudaCall(cuCtxGetDevice(&device));
-#else
-    device = _device;
-#endif
-    return Device(Device::CUdeviceArg(), device);
-  }
-
-  static size_t getLimit(CUlimit limit) {
-    size_t value{};
-    checkCudaCall(cuCtxGetLimit(&value, limit));
-    return value;
-  }
-
-  template <CUlimit limit>
-  static size_t getLimit() {
-    return getLimit(limit);
-  }
-
-  static void setLimit(CUlimit limit, size_t value) {
-    checkCudaCall(cuCtxSetLimit(limit, value));
-  }
-
-  template <CUlimit limit>
-  static void setLimit(size_t value) {
-    setLimit(limit, value);
-  }
-
-  size_t getFreeMemory() const {
-    size_t free;
-    size_t total;
-    checkCudaCall(cuMemGetInfo(&free, &total));
-    return free;
-  }
-
-  size_t getTotalMemory() const {
-    size_t free;
-    size_t total;
-    checkCudaCall(cuMemGetInfo(&free, &total));
-    return total;
-  }
-
-  static void synchronize() {
-#if !defined(__HIP__)
-    checkCudaCall(cuCtxSynchronize());
-#endif
-  }
-
- private:
-  friend class Device;
-  Context(CUcontext context, Device &device)
-      : Wrapper<CUcontext>(context), _device(device) {}
-
-  cu::Device &_device;
 };
 
 class HostMemory : public Wrapper<void *> {

--- a/tests/test_cu.cpp
+++ b/tests/test_cu.cpp
@@ -10,7 +10,6 @@
 TEST_CASE("Test cu::Device", "[device]") {
   cu::init();
   cu::Device device(0);
-  cu::Context context(CU_CTX_SCHED_BLOCKING_SYNC, device);
 
   SECTION("Test Device.getName", "[device]") {
     const std::string name = device.getName();
@@ -37,22 +36,10 @@ TEST_CASE("Test cu::Device", "[device]") {
   }
 }
 
-TEST_CASE("Test context::getDevice", "[device]") {
-  cu::init();
-
-  cu::Device device(0);
-  cu::Context context(CU_CTX_SCHED_BLOCKING_SYNC, device);
-
-  SECTION("Test getName from context") {
-    CHECK(device.getName() == context.getCurrent().getDevice().getName());
-  }
-}
-
 TEST_CASE("Test copying cu::DeviceMemory and cu::HostMemory using cu::Stream",
           "[memcpy]") {
   cu::init();
   cu::Device device(0);
-  cu::Context context(CU_CTX_SCHED_BLOCKING_SYNC, device);
 
   SECTION("Test copying a std::array to the device and back") {
     const std::array<int, 3> src = {1, 2, 3};
@@ -142,7 +129,6 @@ TEST_CASE("Test copying cu::DeviceMemory and cu::HostMemory using cu::Stream",
 TEST_CASE("Test cu::DeviceMemory", "[devicememory]") {
   cu::init();
   cu::Device device(0);
-  cu::Context context(CU_CTX_SCHED_BLOCKING_SYNC, device);
 
   SECTION("Test zeroing cu::DeviceMemory asynchronously") {
     const size_t N = 3;
@@ -267,7 +253,6 @@ using TestTypes = std::tuple<unsigned char, unsigned short, unsigned int>;
 TEMPLATE_LIST_TEST_CASE("Test memset 1D", "[memset]", TestTypes) {
   cu::init();
   cu::Device device(0);
-  cu::Context context(CU_CTX_SCHED_BLOCKING_SYNC, device);
 
   SECTION("Test memset cu::DeviceMemory asynchronously") {
     const size_t N = 3;
@@ -325,7 +310,6 @@ using TestTypes = std::tuple<unsigned char, unsigned short, unsigned int>;
 TEMPLATE_LIST_TEST_CASE("Test memset 2D", "[memset]", TestTypes) {
   cu::init();
   cu::Device device(0);
-  cu::Context context(CU_CTX_SCHED_BLOCKING_SYNC, device);
 
   SECTION("Test memset2D cu::DeviceMemory asynchronously") {
     const size_t width = 3;
@@ -389,7 +373,6 @@ TEMPLATE_LIST_TEST_CASE("Test memset 2D", "[memset]", TestTypes) {
 TEST_CASE("Test cu::Stream", "[stream]") {
   cu::init();
   cu::Device device(0);
-  cu::Context context(CU_CTX_SCHED_BLOCKING_SYNC, device);
   cu::Stream stream;
 
   SECTION("Test memAllocAsync") {

--- a/tests/test_cufft.cpp
+++ b/tests/test_cufft.cpp
@@ -57,7 +57,6 @@ void compare(T *a, T *b, size_t n) {
 TEST_CASE("Test 1D FFT", "[FFT1D]") {
   cu::init();
   cu::Device device(0);
-  cu::Context context(CU_CTX_SCHED_BLOCKING_SYNC, device);
   cu::Stream stream;
 
   const size_t size = 256;
@@ -147,7 +146,6 @@ TEST_CASE("Test 1D FFT", "[FFT1D]") {
 TEST_CASE("Test 2D FFT", "[FFT2D]") {
   cu::init();
   cu::Device device(0);
-  cu::Context context(CU_CTX_SCHED_BLOCKING_SYNC, device);
   cu::Stream stream;
 
   const size_t height = 256;

--- a/tests/test_vector_add.cpp
+++ b/tests/test_vector_add.cpp
@@ -41,7 +41,6 @@ TEST_CASE("Vector add") {
   const size_t bytesize = N * sizeof(float);
 
   cu::Device device(0);
-  cu::Context context(CU_CTX_SCHED_BLOCKING_SYNC, device);
 
   cu::Stream stream;
 
@@ -138,7 +137,7 @@ TEST_CASE("Vector add") {
     initialize_arrays(static_cast<float *>(h_a), static_cast<float *>(h_b),
                       static_cast<float *>(h_c), reference_c.data(), N);
 
-    const size_t memory_free = context.getFreeMemory();
+    const size_t memory_free = cu::getFreeMemory();
 
     cu::DeviceMemory d_a = stream.memAllocAsync(bytesize);
     cu::DeviceMemory d_b = stream.memAllocAsync(bytesize);


### PR DESCRIPTION
Remove the `cu::Context` class. The Context Management is now done in the constructor of the cu::Device class.
When a Primary Context was already active, e.g. when combining cudawrappers with the NVIDIA Runtime API, that context is retained. If not, a new Context is created.

Some tests had to be removed, while others were adapted slightly. When building in HIP mode, the Context code is disabled. The code is tested locally on NVIDIA en AMD en all pass.

**Description**

<!-- Description of PR -->

**Related issues**:

- https://github.com/nlesc-recruit/cudawrappers/issues/306
- https://github.com/nlesc-recruit/cudawrappers/issues/313

**Instructions to review the pull request**

- Check that CHANGELOG.md has been updated if necessary

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```
-->

<!--
Review online.
-->
