### PR TITLE
Fix formatting of filename in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@
 
 **Instructions to review the pull request**
 
-- Check that CHANGELOG.md has been updated if necessary
+- Check that `CHANGELOG.md` has been updated if necessary
 
 <!--
 Clone and verify


### PR DESCRIPTION
**Description**

A very minor change, it just looks better with proper formatting.

**Related issues**:

- ...

**Instructions to review the pull request**

- Check that `CHANGELOG.md` has been updated if necessary

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```
-->

<!--
Review online.
-->
