### PR TITLE
Prepare for release 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,27 +7,24 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Added compatibility with HIP
-- Added `cu::Device::getArch()`
+- Added HIP compatibility
+- Added `cu::Device::getArch()` and `cu::Device::getOrdinal()`
 - Added `cu::DeviceMemory` constructor to create non-owning slice of another
   `cu::DeviceMemory` object
-- Added `cu::DeviceMemory::memset()`
-- Added `cu::Stream::memsetAsync()`
-- Added `nvml::Device::getPower()`
+- Added `cu::DeviceMemory::memset()`,`cu::DeviceMemory::memset2D()`
+- Added `cu::Stream::memsetAsync()` and `cu::Stream::memset2DAsync()`
 - Added `cu::Stream::memcpyHtoD2DAsync()`, `cu::Stream::memcpyDtoHD2Async()`,
   and `cu::Stream::memcpyDtoD2DAsync()`
-- Added `cu::DeviceMemory::memset2D()` and `cu::Stream::memset2DAsync()`
 - Added `cufft::FFT1DR2C` and `cufft::FFT1DC2R`
-- Added `cu::Device::getOrdinal()`
-- Improved HIP documentation and building instructions
+- Added `nvml::Device::getPower()`
 
 ### Changed
 
 - `cu::Context::{getCurrent, popCurrent, getDevice}` are no longer static
-- `inline_local_includes` is now more robust: it properly handles commented
-  includes and respects the location of an include in the original source file
 - Upgrade C++ standard to C++14
 - Upgrade Catch2 to version v3.6.0
+- `inline_local_includes` is now more robust: it properly handles commented
+  includes and respects the location of an include in the original source file
 - `target_embed_source` is now more robust: it properly tracks dependencies and
   runs again whenever any of them changes
 - Expanded tests to cover the new 2D memory operations and FFT support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased
+## [0.9.0] - 2025-03-18
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Added `cu::DeviceMemory::memset2D()` and `cu::Stream::memset2DAsync()`
 - Added `cufft::FFT1DR2C` and `cufft::FFT1DC2R`
 - Added `cu::Device::getOrdinal()`
-- Added deprecated warning to `cu::Context` constructor
 - Improved HIP documentation and building instructions
 
 ### Changed

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -215,8 +215,7 @@ class Context : public Wrapper<CUcontext> {
  public:
   // Context Management
 
-  Context(int flags, Device &device)
-      : _device(device) {
+  Context(int flags, Device &device) : _device(device) {
 #if !defined(__HIP__)
     checkCudaCall(cuCtxCreate(&_obj, flags, device));
     manager =

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -215,7 +215,6 @@ class Context : public Wrapper<CUcontext> {
  public:
   // Context Management
 
-  [[deprecated("cu::Context is deprecated since cudawrappers version 0.9.0.")]]
   Context(int flags, Device &device)
       : _device(device) {
 #if !defined(__HIP__)


### PR DESCRIPTION
**Description**

To prepare for release of version `0.9.0`, https://github.com/nlesc-recruit/cudawrappers/pull/310 has been reverted, and the internal version numbers are updated. The entries in the changelog have been grouped and slightly cleaned-up.

**Related issues**:

- https://github.com/nlesc-recruit/cudawrappers/pull/310

