### PR TITLE
Explicitly set device in HIP instead of relying on context management

### DIFF
--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -130,6 +130,11 @@ class Device : public Wrapper<CUdevice> {
 
   explicit Device(int ordinal) : _ordinal(ordinal) {
     checkCudaCall(cuDeviceGet(&_obj, ordinal));
+#if defined(__HIP__)
+    // the device is not set through context management in HIP,
+    // so set it explicitly here
+    checkCudaCall(hipSetDevice(ordinal));
+#endif
   }
 
   struct CUdeviceArg {

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -131,8 +131,8 @@ class Device : public Wrapper<CUdevice> {
   explicit Device(int ordinal) : _ordinal(ordinal) {
     checkCudaCall(cuDeviceGet(&_obj, ordinal));
 #if defined(__HIP__)
-    // the device is not set through context management in HIP,
-    // so set it explicitly here
+    // The device is not set through context management in HIP,
+    // so it is set explicitly here.
     checkCudaCall(hipSetDevice(ordinal));
 #endif
   }


### PR DESCRIPTION
Context management is no-op in HIP, so using a device other than 0 did not work (see #320).

On a system where devices are as follows:
```
device 0: AMD Radeon RX 7900 XT
device 1: AMD Radeon Graphics
```
, the code in the linked issue now correctly prints
```
AMD Radeon Graphics
1
```
Instead of 
```
AMD Radeon Graphics
0
```

An explicit call to the hip function `hipSetDevice` is used, instead of relying on a cuda version + cudawrappers macros, as there is no cuda driver equivalent to this function.

Closes #320 