### PR TITLE
Upgrade residual version numbers/dates

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.8.0
+current_version = 0.9.0
 
 [bumpversion:file:docs/conf.py]
 search = release = '{current_version}'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -78,7 +78,6 @@ identifiers:
     value: 10.5281/zenodo.6076447
     description: The concept doi for all versions of the software.
 repository-code: 'https://github.com/nlesc-recruit/cudawrappers'
-abstract: C++ Wrappers for the CUDA Driver API.
 keywords:
   - CUDA
   - HIP
@@ -87,4 +86,4 @@ keywords:
   - accelerators
 license: Apache-2.0
 date-released: 2022-03-08
-version: "0.8.0"
+version: "0.9.0"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 project(
   cudawrappers
   DESCRIPTION "C++ Wrappers for the CUDA Driver API"
-  VERSION 0.8.0
+  VERSION 0.9.0
   HOMEPAGE_URL https://github.com/nlesc-recruit/cudawrappers
   LANGUAGES CXX
 )

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,11 +18,11 @@
 # -- Project information -----------------------------------------------------
 
 project = 'cudawrappers'
-copyright = '2022, cudawrappers developers'
+copyright = '2025, cudawrappers developers'
 author = 'cudawrappers developers'
 
 # The full version, including alpha/beta/rc tags
-release = '0.8.0'
+release = '0.9.0'
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
The version number was not bumped from `0.8.0` to `0.9.0`, the data in de `docs.conf` wasn't updated and Zenodo can generate a nicer description if no abstract is provided in the citation file.