### PR TITLE
Use cu::Context in cu::Graph

### DIFF
--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -790,17 +790,16 @@ class GraphMemCopyToHostNodeParams : public Wrapper<CUDA_MEMCPY3D> {
 
 class Graph : public Wrapper<CUgraph> {
  public:
-  explicit Graph(CUgraph &graph) : Wrapper(graph) {
-    checkCudaCall(cuCtxGetCurrent(&_context));
-  };
+  explicit Graph(cu::Context &context, CUgraph &graph)
+      : Wrapper(graph), _context(context) {};
 
-  explicit Graph(unsigned int flags = CU_GRAPH_DEFAULT) {
+  explicit Graph(cu::Context &context, unsigned int flags = CU_GRAPH_DEFAULT)
+      : _context(context) {
     checkCudaCall(cuGraphCreate(&_obj, flags));
     manager = std::shared_ptr<CUgraph>(new CUgraph(_obj), [](CUgraph *ptr) {
       checkCudaCall(cuGraphDestroy(*ptr));
       delete ptr;
     });
-    cuCtxGetCurrent(&_context);
   }
 
   void addKernelNode(GraphNode &node,
@@ -882,7 +881,7 @@ class Graph : public Wrapper<CUgraph> {
   }
 
  private:
-  CUcontext _context;
+  cu::Context _context;
 };
 
 class GraphExec : public Wrapper<CUgraphExec> {

--- a/tests/test_graph.cpp
+++ b/tests/test_graph.cpp
@@ -34,7 +34,7 @@ TEST_CASE("Test cu::Graph", "[graph]") {
       int* ptr = static_cast<int*>(data);
       *ptr += 1;
     };
-    cu::Graph graph;
+    cu::Graph graph(context);
     int data = 42;
     cu::GraphHostNodeParams node_params(fn, &data);
 
@@ -62,7 +62,7 @@ TEST_CASE("Test cu::Graph", "[graph]") {
       data_in[i] = 3;
     }
 
-    cu::Graph graph;
+    cu::Graph graph(context);
     cu::GraphNode dev_alloc, host_set, copy_to_dev, execute_kernel, device_free,
         copy_to_host;
     struct set_value_parameter {
@@ -129,7 +129,7 @@ TEST_CASE("Test cu::Graph", "[graph]") {
     constexpr size_t array_size = 3;
     std::array<float, array_size> data_in{3, 3, 3};
     std::array<float, array_size> data_out{0, 0, 0};
-    cu::Graph graph;
+    cu::Graph graph(context);
     cu::GraphNode dev_alloc, host_set, copy_to_dev, execute_kernel, device_free,
         copy_to_host, host_set2;
 


### PR DESCRIPTION
Use `cu::Context` in  `cu::Graph` instead of directly accessing `CUDA` / `HIP` context functions. This avoids using HIP contexts while these are deprecated, see issue #327. 

This is an API-breaking change: a `cu::Context` object now needs to be passed to the `cu::Graph` constructor.

I ran the tests on both an NVIDIA and AMD GPU and all pass.

Note: `cu::Graph` is not mentioned in the changelog at all, so I thought it would be strange to mention changes to it in this PR. Perhaps a note of the addition of graph support should be added in a separate PR?
