### PR TITLE
Add mangled name support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Added
+
+- Added `nvrtc::addNameExpression` and `nvrtc::getLoweredName`
+
 ## [0.9.0] - 2025-03-18
 
 ### Added

--- a/include/cudawrappers/nvrtc.hpp
+++ b/include/cudawrappers/nvrtc.hpp
@@ -152,6 +152,16 @@ class Program {
     return log;
   }
 
+  void addNameExpression(const std::string &name) {
+    checkNvrtcCall(nvrtcAddNameExpression(program, name.c_str()));
+  }
+
+  const char *getLoweredName(const std::string &name) {
+    const char *lowered_name;
+    checkNvrtcCall(nvrtcGetLoweredName(program, name.c_str(), &lowered_name));
+    return lowered_name;
+  }
+
  private:
   nvrtcProgram program{};
 };

--- a/tests/kernels/vector_add_kernel.cu
+++ b/tests/kernels/vector_add_kernel.cu
@@ -1,4 +1,4 @@
-extern "C" __global__ void vector_add(float *c, float *a, float *b, int n) {
+__global__ void vector_add(float *c, float *a, float *b, int n) {
   int i = blockIdx.x * blockDim.x + threadIdx.x;
   if (i < n) {
     c[i] = a[i] + b[i];


### PR DESCRIPTION
**Description**

Add support for `nvrtcAddNameExpression` and `nvrtcGetLoweredName`, and their hiprtc equivalents. I think it might be nice to hide this complexity from the user entirely, but that would be quite a bit more work as the user typically gives the function name only to `cu::Function`, which knows nothing about `nvrtc`.

I didn't add an explicit test for the new functionality, but instead removed `extern "C"` from all kernels in the tests. This causes the compiler to mangle the names which is then handled by the new functionality.

**Related issues**:
Closes #281 

**Instructions to review the pull request**

- Check that `CHANGELOG.md` has been updated if necessary
- Run tests on with both CUDA and HIP