### PR TITLE
Add test for nvtx

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,7 +10,7 @@ FetchContent_MakeAvailable(Catch2)
 list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/contrib)
 include(Catch)
 
-set(COMPONENTS cu nvrtc cufft vector_add graph)
+set(COMPONENTS cu nvrtc cufft vector_add graph nvtx)
 if(${CUDAWRAPPERS_BACKEND_CUDA})
   list(APPEND COMPONENTS nvml)
 endif()
@@ -45,3 +45,5 @@ target_link_libraries(
 )
 
 target_link_libraries(test_graph PUBLIC ${LINK_LIBRARIES} cudawrappers::nvrtc)
+
+target_link_libraries(test_nvtx PUBLIC ${LINK_LIBRARIES} cudawrappers::nvtx)

--- a/tests/test_nvtx.cpp
+++ b/tests/test_nvtx.cpp
@@ -1,0 +1,15 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <cudawrappers/cu.hpp>
+#include <cudawrappers/nvtx.hpp>
+
+TEST_CASE("Test nvtx Marker creation", "[marker]") {
+  nvtx::Marker marker("message");
+}
+
+TEST_CASE("Test nvtx Marker use", "[marker-use]") {
+  nvtx::Marker marker("message", nvtx::Marker::red);
+  marker.start();
+  cu::init();
+  marker.end();
+}


### PR DESCRIPTION
Originally I wanted to look into roctx (#295), but it seems AMD is deprecating that tool in favour of rocprofiler-sdk, which is still in beta. To prepare I did already add a test for nvtx, which is the purpose of this PR. This fixes #219.

In addition to passing tests, I confirmed that Nsight Systems shows the nvtx markers as set by the test program, in the expected colour.