### PR TITLE
include `cudawrappers-inline-local-includes.cmake` in the installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,10 +113,12 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
   )
 
   install(
-    FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake
-          ${CMAKE_CURRENT_BINARY_DIR}/cudawrappers-config.cmake
-          ${CMAKE_CURRENT_SOURCE_DIR}/cmake/cudawrappers-helper.cmake
-          ${CMAKE_CURRENT_SOURCE_DIR}/cmake/cudawrappers-dependencies.cmake
+    FILES
+      ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake
+      ${CMAKE_CURRENT_BINARY_DIR}/cudawrappers-config.cmake
+      ${CMAKE_CURRENT_SOURCE_DIR}/cmake/cudawrappers-helper.cmake
+      ${CMAKE_CURRENT_SOURCE_DIR}/cmake/cudawrappers-dependencies.cmake
+      ${CMAKE_CURRENT_SOURCE_DIR}/cmake/cudawrappers-inline-local-includes.cmake
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
   )
 


### PR DESCRIPTION
**Description**

The current build does not install the cmake file, `cmake/cudawrappers-inline-local-includes.cmake`. This leads to build errors when `target_embed_source` function is used, which adds a dependency to this file. 
https://github.com/nlesc-recruit/cudawrappers/blob/adecd500fb803021aa11ef0b200ad1ebbdc47591/cmake/cudawrappers-helper.cmake#L42-L48
This PR fixes the `CMakeLists.txt` to include this cmake file in the install directory.

**Related issues**:

- None

**Instructions to review the pull request**

- Check that `CHANGELOG.md` has been updated if necessary

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```
-->

<!--
Review online.
-->
