### PR TITLE
Fix cu::DeviceMemory constructors with CUdeviceptr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Changed
+
+- Bugfix `cu::DeviceMemory` constructors with `CUdeviceptr` argument.
+
 ## [0.9.0] - 2025-03-18
 
 ### Added

--- a/include/cudawrappers/cu.hpp
+++ b/include/cudawrappers/cu.hpp
@@ -571,10 +571,17 @@ class DeviceMemory : public Wrapper<CUdeviceptr> {
                                            });
   }
 
-  explicit DeviceMemory(CUdeviceptr ptr) : Wrapper(ptr) {}
+  explicit DeviceMemory(CUdeviceptr ptr) {
+    _obj = ptr;
+    manager = std::shared_ptr<CUdeviceptr>(&ptr, [](CUdeviceptr *ptr) {});
+  }
 
-  explicit DeviceMemory(CUdeviceptr ptr, size_t size)
-      : Wrapper(ptr), _size(size) {}
+  explicit DeviceMemory(CUdeviceptr ptr, size_t size) : _size(size) {
+    _obj = ptr;
+    manager = std::shared_ptr<CUdeviceptr>(&ptr, [](CUdeviceptr *ptr) {
+
+    });
+  }
 
   explicit DeviceMemory(const HostMemory &hostMemory) {
     checkCudaCall(cuMemHostGetDevicePointer(&_obj, hostMemory, 0));


### PR DESCRIPTION
**Description**

As identified [here](https://git.astron.nl/RD/recruit/ccglib/-/merge_requests/74#note_116140), the `cu::DeviceMemory` constructor that accept a `CUdeviceptr` cause issues. There are two problems:
- The `_obj` member is not initialized to `ptr` as it should.
- The `manager` is initialized to `cu::Wrapper`, while the `ptr` should not be managed at all.

The problem is solved by explicitly initializing `_obj` and by initializing `manager`  with an empty deleter.


<!-- Description of PR -->

**Related issues**:

- N.A.

**Instructions to review the pull request**

- Check that `CHANGELOG.md` has been updated if necessary

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```
-->

<!--
Review online.
-->
