### PR TITLE
Reimplement source embedding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Added `nvrtc::addNameExpression` and `nvrtc::getLoweredName`
+- Added header file to ease the use of embedded kernel sources
 
 ### Changed
 

--- a/cmake/cudawrappers-helper.cmake
+++ b/cmake/cudawrappers-helper.cmake
@@ -39,9 +39,6 @@ function(target_embed_source target_name input_file)
     COMMENT "Inlining all includes of ${input_file}"
   )
 
-  string(REPLACE "." "_" symbol_base "${output_source_file}")
-  string(REPLACE "/" "_" symbol_base "${symbol_base}")
-
   add_custom_command(
     OUTPUT "${output_object_file}"
     COMMAND ${CMAKE_LINKER} -r -b binary -A ${CMAKE_SYSTEM_PROCESSOR} -o
@@ -51,7 +48,11 @@ function(target_embed_source target_name input_file)
     VERBATIM
   )
 
-  set(header_file "${CMAKE_BINARY_DIR}/${output_source_file}.h")
+  string(REPLACE "." "_" symbol_base "${output_source_file}")
+  string(REPLACE "/" "_" symbol_base "${symbol_base}")
+
+  set(header_file "${output_object_file}.h")
+  set(header_file "${CMAKE_BINARY_DIR}/${header_file}")
   set(header_content
       "
 extern const unsigned char _binary_${symbol_base}_start[];
@@ -65,6 +66,6 @@ extern const unsigned int  _binary_${symbol_base}_size;
 
   add_library(${input_basename} STATIC "${output_object_file}")
   set_target_properties(${input_basename} PROPERTIES LINKER_LANGUAGE CXX)
-  target_include_directories(${input_basename} PUBLIC "${CMAKE_BINARY_DIR}")
+  target_include_directories(${target_name} PUBLIC ${CMAKE_BINARY_DIR})
   target_link_libraries(${target_name} PRIVATE ${input_basename})
 endfunction()

--- a/cmake/cudawrappers-helper.cmake
+++ b/cmake/cudawrappers-helper.cmake
@@ -10,7 +10,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/inline-common.cmake")
 # Produces:
 #   - A generated inlined source file with all local includes
 #   - A binary object (.o) compiled from it
-#   - A header file exposing _start, _end, _size symbols
+#   - A header file exposing _start, _end, _size symbols and a helper function
 #   - A static library target named after the input file's basename
 #   - Links this static library to the provided target
 #
@@ -58,6 +58,12 @@ function(target_embed_source target_name input_file)
 extern const unsigned char _binary_${symbol_base}_start[];
 extern const unsigned char _binary_${symbol_base}_end[];
 extern const unsigned int  _binary_${symbol_base}_size;
+
+inline std::string ${input_basename}_source() {
+    return std::string(
+        reinterpret_cast<const char*>(_binary_${symbol_base}_start),
+        reinterpret_cast<const char*>(_binary_${symbol_base}_end));
+}
 "
   )
 

--- a/cmake/cudawrappers-helper.cmake
+++ b/cmake/cudawrappers-helper.cmake
@@ -62,11 +62,9 @@ extern const unsigned char _binary_${symbol_base}_start[];
 extern const unsigned char _binary_${symbol_base}_end[];
 extern const unsigned int  _binary_${symbol_base}_size;
 
-inline std::string ${input_basename}_source() {
-    return std::string(
+const std::string ${input_basename}_source = std::string(
         reinterpret_cast<const char*>(_binary_${symbol_base}_start),
         reinterpret_cast<const char*>(_binary_${symbol_base}_end));
-}
 
 #endif // ${include_guard}
 "

--- a/cmake/cudawrappers-helper.cmake
+++ b/cmake/cudawrappers-helper.cmake
@@ -30,7 +30,7 @@ function(target_embed_source target_name input_file)
   get_dependencies("${input_path}" all_deps processed_files)
 
   add_custom_command(
-    OUTPUT "${CMAKE_BINARY_DIR}/${output_source_file}"
+    OUTPUT "${output_source_file}"
     COMMAND
       ${CMAKE_COMMAND} -Dinput_file="${input_path}"
       -Doutput_file="${output_source_file}" -Droot_dir="${PROJECT_SOURCE_DIR}"

--- a/cmake/cudawrappers-helper.cmake
+++ b/cmake/cudawrappers-helper.cmake
@@ -51,10 +51,13 @@ function(target_embed_source target_name input_file)
   string(REPLACE "." "_" symbol_base "${output_source_file}")
   string(REPLACE "/" "_" symbol_base "${symbol_base}")
 
+  string(TOUPPER "${input_basename}_H_" include_guard)
   set(header_file "${output_object_file}.h")
   set(header_file "${CMAKE_BINARY_DIR}/${header_file}")
   set(header_content
-      "
+      "#ifndef ${include_guard}
+#define ${include_guard}
+
 extern const unsigned char _binary_${symbol_base}_start[];
 extern const unsigned char _binary_${symbol_base}_end[];
 extern const unsigned int  _binary_${symbol_base}_size;
@@ -64,6 +67,8 @@ inline std::string ${input_basename}_source() {
         reinterpret_cast<const char*>(_binary_${symbol_base}_start),
         reinterpret_cast<const char*>(_binary_${symbol_base}_end));
 }
+
+#endif // ${include_guard}
 "
   )
 

--- a/cmake/cudawrappers-helper.cmake
+++ b/cmake/cudawrappers-helper.cmake
@@ -1,152 +1,70 @@
-# =============================================================================
-# cmake-format: off
-# This module enables embedding kernel or source files (e.g. .cu) into targets
-# by linking their binary representation as static libraries. It also inlines
-# any local includes (#include "...") in the source file.
-#
-# Functions:
-#   - get_local_includes: Recursively collect local includes.
-#   - inline_local_includes: Prepend headers and remove #include "..."
-#   - target_embed_source: Embed a source file as binary and link to a target.
-#
-# cmake-format: on
-# =============================================================================
+include("${CMAKE_CURRENT_LIST_DIR}/inline-common.cmake")
 
 # cmake-format: off
-# Return a list of absolute file names for all the local includes of the
-# input_file. Only files in the root_dir will be considered.
 #
-# Parameters:
-#   input_file: The file to scan for includes
-#   root_dir:   The root directory in which to search for include files
-#   out_var:    Output variable name to receive the list of include files (absolute paths)
-# cmake-format: on
-# get_local_includes
-function(get_local_includes input_file root_dir out_var)
-  file(READ "${input_file}" input_file_content)
-  set(include_regex "(^|\r?\n)(#include[ \t]*\"([^\"]+)\")")
-  string(REGEX MATCHALL "${include_regex}" includes "${input_file_content}")
-
-  set(include_files_local "")
-
-  foreach(include ${includes})
-    # Extract the filename from the include directive
-    string(REGEX REPLACE "${include_regex}" "\\3" include_name "${include}")
-    file(GLOB_RECURSE include_paths "${root_dir}/*/${include_name}")
-    if(include_paths)
-      list(SORT include_paths ORDER DESCENDING)
-      list(GET include_paths 0 include_path)
-      get_local_includes("${include_path}" "${root_dir}" recursive_includes)
-      list(APPEND include_files_local ${recursive_includes} "${include_path}")
-    else()
-      message(
-        WARNING "Could not find include: ${include_name} in ${input_file}"
-      )
-    endif()
-  endforeach()
-
-  list(REMOVE_DUPLICATES include_files_local)
-  set(${out_var}
-      "${include_files_local}"
-      PARENT_SCOPE
-  )
-endfunction()
-
-# cmake-format: off
-# Create a new file with inlined (prepended) headers and local #include "..."
-# lines removed from the input file.
+# Inline a C/C++ source file with local includes as a binary object using `ld -b binary`.
 #
-# Parameters:
-#   input_file:     Absolute path to main source file
-#   output_file:    File to write the resulting inlined source
-#   include_files:  List of absolute paths to the files to inline
-# cmake-format: on
-# inline_local_includes
-function(inline_local_includes input_file output_file include_files)
-  file(READ "${input_file}" input_file_content)
-  set(include_regex "(^|\r?\n)(#include[ \t]*\"([^\"]+)\")")
-  string(REGEX REPLACE "${include_regex}" "" input_file_content
-                       "${input_file_content}"
-  )
-
-  set(output_content "")
-  foreach(include_file ${include_files})
-    file(READ "${include_file}" include_file_content)
-    string(REGEX REPLACE "${include_regex}" "" include_file_content
-                         "${include_file_content}"
-    )
-    set(output_content "${output_content}\n${include_file_content}")
-  endforeach()
-
-  set(output_content "${output_content}\n${input_file_content}")
-  file(WRITE "${output_file}" "${output_content}")
-endfunction()
-
-# cmake-format: off
-# Embed a source file in a static library and link it to a target. It inlines
-# any local includes (#include "...")
+# Usage:
+#   target_embed_source(<target_name> <input_file>)
 #
-# Parameters:
-#   target:     CMake target to link to
-#   input_file: Path to the file to embed
+# Produces:
+#   - A generated inlined source file with all local includes
+#   - A binary object (.o) compiled from it
+#   - A header file exposing _start, _end, _size symbols
+#   - A static library target named after the input file's basename
+#   - Links this static library to the provided target
+#
 # cmake-format: on
-# target_embed_source
-function(target_embed_source target input_file)
-  include(CMakeDetermineSystem)
+#
+# target_embed_source(<target_name> <input_file>)
+function(target_embed_source target_name input_file)
+  get_filename_component(input_name "${input_file}" NAME)
+  get_filename_component(input_basename "${input_file}" NAME_WE)
+  get_filename_component(input_path "${input_file}" REALPATH)
 
-  get_filename_component(name "${input_file}" NAME_WLE)
-  get_filename_component(input_file_absolute "${input_file}" REALPATH)
+  file(RELATIVE_PATH output_source_file "${PROJECT_SOURCE_DIR}" "${input_path}")
+  set(output_object_file "${output_source_file}.o")
 
-  string(REPLACE "${PROJECT_SOURCE_DIR}" "${CMAKE_BINARY_DIR}"
-                 input_file_inlined "${input_file_absolute}"
-  )
-
-  get_filename_component(
-    input_file_inlined_dir "${input_file_inlined}" DIRECTORY
-  )
-  file(MAKE_DIRECTORY "${input_file_inlined_dir}")
-
-  get_local_includes(
-    "${input_file_absolute}" "${PROJECT_SOURCE_DIR}" include_files
-  )
-
-  if("${include_files}" STREQUAL "")
-    configure_file("${input_file_absolute}" "${input_file_inlined}" COPYONLY)
-  else()
-    inline_local_includes(
-      "${input_file_absolute}" "${input_file_inlined}" "${include_files}"
-    )
-  endif()
-
-  file(RELATIVE_PATH input_file_inlined_relative "${PROJECT_SOURCE_DIR}"
-       "${input_file_absolute}"
-  )
-
-  set(embed_object_file "${CMAKE_CURRENT_BINARY_DIR}/${name}.o")
-  set(embed_tool ld)
-  set(embed_tool_args
-      -r
-      -b
-      binary
-      -A
-      ${CMAKE_SYSTEM_PROCESSOR}
-      -o
-      "${embed_object_file}"
-      "${input_file_inlined_relative}"
-  )
+  set(all_deps "")
+  set(processed_files "")
+  get_dependencies("${input_path}" all_deps processed_files)
 
   add_custom_command(
-    OUTPUT "${embed_object_file}"
-    COMMAND ${embed_tool} ARGS ${embed_tool_args}
-    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
-    DEPENDS "${input_file_absolute}" "${input_file_inlined}" ${include_files}
-    COMMENT "Creating object file for ${input_file}"
+    OUTPUT "${CMAKE_BINARY_DIR}/${output_source_file}"
+    COMMAND
+      ${CMAKE_COMMAND} -Dinput_file="${input_path}"
+      -Doutput_file="${output_source_file}" -Droot_dir="${PROJECT_SOURCE_DIR}"
+      -P "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/inline-local-includes.cmake"
+    DEPENDS "${input_path}" ${all_deps}
+    COMMENT "Inlining all includes of ${input_file}"
   )
 
-  if(NOT TARGET ${name})
-    add_library(${name} STATIC "${embed_object_file}")
-    set_target_properties(${name} PROPERTIES LINKER_LANGUAGE CXX)
-  endif()
+  string(REPLACE "." "_" symbol_base "${output_source_file}")
+  string(REPLACE "/" "_" symbol_base "${symbol_base}")
 
-  target_link_libraries(${target} PRIVATE ${name})
+  add_custom_command(
+    OUTPUT "${output_object_file}"
+    COMMAND ${CMAKE_LINKER} -r -b binary -A ${CMAKE_SYSTEM_PROCESSOR} -o
+            "${output_object_file}" "${output_source_file}"
+    DEPENDS "${output_source_file}"
+    COMMENT "Creating object file for ${input_file}"
+    VERBATIM
+  )
+
+  set(header_file "${CMAKE_BINARY_DIR}/${output_source_file}.h")
+  set(header_content
+      "
+extern const unsigned char _binary_${symbol_base}_start[];
+extern const unsigned char _binary_${symbol_base}_end[];
+extern const unsigned int  _binary_${symbol_base}_size;
+"
+  )
+
+  file(WRITE "${header_file}.in" "${header_content}")
+  configure_file("${header_file}.in" "${header_file}" @ONLY)
+
+  add_library(${input_basename} STATIC "${output_object_file}")
+  set_target_properties(${input_basename} PROPERTIES LINKER_LANGUAGE CXX)
+  target_include_directories(${input_basename} PUBLIC "${CMAKE_BINARY_DIR}")
+  target_link_libraries(${target_name} PRIVATE ${input_basename})
 endfunction()

--- a/cmake/inline-common.cmake
+++ b/cmake/inline-common.cmake
@@ -1,0 +1,55 @@
+# cmake-format: off
+#
+# Common CMake utilities for source file inlining.
+#
+# Provides:
+#   - get_dependencies(input deps_var processed_var)
+#
+# Description:
+#   Recursively collects local dependencies from a C/C++ source file by scanning
+#   for quote-style includes (e.g., #include "header.h").
+#
+#   The result is stored in a list variable <deps_var>, with duplicate prevention
+#   using a <processed_var> list to track visited files.
+#
+#   Intended for use in scripts that inline or bundle source files.
+
+# cmake-format: on
+#
+# get_dependencies(<input> <deps_var> <processed_var>)
+function(get_dependencies input deps_var processed_var)
+  list(FIND ${processed_var} "${input}" idx)
+  if(NOT idx EQUAL -1)
+    return()
+  endif()
+
+  list(APPEND ${processed_var} "${input}")
+
+  file(READ "${input}" content)
+  string(REGEX MATCHALL "#[ \t]*include[ \t]+\"([^\"]+)\"" includes
+               "${content}"
+  )
+
+  get_filename_component(input_dir "${input}" DIRECTORY)
+
+  foreach(match IN LISTS includes)
+    string(REGEX REPLACE "#[ \t]*include[ \t]+\"([^\"]+)\"" "\\1" included_file
+                         "${match}"
+    )
+    set(full_path "${input_dir}/${included_file}")
+
+    if(EXISTS "${full_path}")
+      get_dependencies("${full_path}" ${deps_var} ${processed_var})
+      list(APPEND ${deps_var} "${full_path}")
+    endif()
+  endforeach()
+
+  set(${deps_var}
+      "${${deps_var}}"
+      PARENT_SCOPE
+  )
+  set(${processed_var}
+      "${${processed_var}}"
+      PARENT_SCOPE
+  )
+endfunction()

--- a/cmake/inline-local-includes.cmake
+++ b/cmake/inline-local-includes.cmake
@@ -1,0 +1,69 @@
+include("${CMAKE_CURRENT_LIST_DIR}/inline-common.cmake")
+
+# cmake-format: off
+#
+# Copy the contents of the input file to the output file with all the local
+# includes inlined. Local includes are assumed to use quotes (""), e.g.
+# '#include "helper.h"' will cause `helper.h` to be inlined recursively. Only
+# files within the root directory are considered.
+# Inline all local includes in a C/C++ source file by recursively expanding
+# quoted includes (e.g., #include "header.h") into a single flat source file.
+#
+# Usage:
+#   Called via -P in CMake script mode with the following variables defined:
+#     - input_file: Path to the source file with includes
+#     - output_file: Path to write the inlined result
+#     - root_dir: Project root directory (used to search for includes)
+#
+# Behavior:
+#   - Recursively resolves and inlines only quote-style includes ("...").
+#   - Only files within the root directory are considered.
+#   - Skips duplicate includes (once per file).
+#
+# cmake-format: on
+# inline_local_includes(<input_file> <output_string> <root_dir>)
+function(inline_local_includes input_file output_string root_dir)
+  file(READ "${input_file}" input_contents)
+
+  string(REGEX MATCHALL "(^|\r?\n)#include[ \t]*\"([^\"]+)\"" includes
+               "${input_contents}"
+  )
+
+  set(processed_files "")
+  set(already_included "")
+
+  foreach(match IN LISTS includes)
+    string(REGEX REPLACE "(^|\r?\n)#include[ \t]*\"([^\"]+)\"" "\\2"
+                         include_name "${match}"
+    )
+    file(GLOB_RECURSE found_paths "${root_dir}/*/${include_name}")
+    if(NOT found_paths STREQUAL "")
+      list(SORT found_paths ORDER DESCENDING)
+      list(GET found_paths 0 include_path)
+
+      list(FIND already_included "${include_path}" found_idx)
+      if(found_idx EQUAL -1)
+        list(APPEND already_included "${include_path}")
+        set(include_contents "")
+        inline_local_includes("${include_path}" include_contents "${root_dir}")
+        string(REPLACE "#include \"${include_name}\"" "${include_contents}"
+                       input_contents "${input_contents}"
+        )
+      else()
+        string(REPLACE "#include \"${include_name}\"" "" input_contents
+                       "${input_contents}"
+        )
+      endif()
+    endif()
+  endforeach()
+
+  set(${output_string}
+      "${input_contents}"
+      PARENT_SCOPE
+  )
+endfunction()
+
+# Entry point
+set(OUTPUT_STRING "")
+inline_local_includes("${input_file}" OUTPUT_STRING "${root_dir}")
+file(WRITE "${output_file}" "${OUTPUT_STRING}")

--- a/tests/test_nvrtc.cpp
+++ b/tests/test_nvrtc.cpp
@@ -34,7 +34,7 @@ TEST_CASE("Test nvrtc::Program", "[program]") {
 #include "tests/kernels/vector_add_kernel.cu.o.h"
 
 TEST_CASE("Test nvrtc::Program embedded source", "[program]") {
-  nvrtc::Program program(vector_add_kernel_source(), "vector_add_kernel.cu");
+  nvrtc::Program program(vector_add_kernel_source, "vector_add_kernel.cu");
 
 #if defined(__HIP__)
   const std::vector<std::string> options = {"-ffast-math"};

--- a/tests/test_nvrtc.cpp
+++ b/tests/test_nvrtc.cpp
@@ -31,13 +31,10 @@ TEST_CASE("Test nvrtc::Program", "[program]") {
   }
 }
 
-extern const char _binary_tests_kernels_vector_add_kernel_cu_start,
-    _binary_tests_kernels_vector_add_kernel_cu_end;
+#include "tests/kernels/vector_add_kernel.cu.o.h"
 
 TEST_CASE("Test nvrtc::Program embedded source", "[program]") {
-  const std::string kernel(&_binary_tests_kernels_vector_add_kernel_cu_start,
-                           &_binary_tests_kernels_vector_add_kernel_cu_end);
-  nvrtc::Program program(kernel, "vector_add_kernel.cu");
+  nvrtc::Program program(vector_add_kernel_source(), "vector_add_kernel.cu");
 
 #if defined(__HIP__)
   const std::vector<std::string> options = {"-ffast-math"};


### PR DESCRIPTION
**Description**

While https://github.com/nlesc-recruit/cudawrappers/pull/337 and https://github.com/nlesc-recruit/cudawrappers/pull/339 intended to make the inlining of kernel source files more robust, we noticed that dependency tracking using the latest code is now not (reliably) working anymore.

The CMake code is implemented once more. The `test_nvrtc` passes. Moreover, several tests on code not part of this repository also show that the code is behaving as expected.

As a bonus, the CMake helper now writes a header file that simplifies the code that uses inlined sources. This is demonstrated in `test_nvrtc`.

**Related issues**:

- N.A.

**Instructions to review the pull request**

- Check that `CHANGELOG.md` has been updated if necessary

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```
-->

<!--
Review online.
-->
