### PR TITLE
Replace REALPATH with ABSOLUTE

### DIFF
--- a/cmake/cudawrappers-helper.cmake
+++ b/cmake/cudawrappers-helper.cmake
@@ -20,7 +20,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/inline-common.cmake")
 function(target_embed_source target_name input_file)
   get_filename_component(input_name "${input_file}" NAME)
   get_filename_component(input_basename "${input_file}" NAME_WE)
-  get_filename_component(input_path "${input_file}" REALPATH)
+  get_filename_component(input_path "${input_file}" ABSOLUTE)
 
   file(RELATIVE_PATH output_source_file "${PROJECT_SOURCE_DIR}" "${input_path}")
   set(output_object_file "${output_source_file}.o")


### PR DESCRIPTION
**Description**

https://github.com/nlesc-recruit/cudawrappers/pull/342 introduced a bug in an edge-case, when kernel sources are located in a symlinked directory. The use of `REALPATH` dereferences the symbolic links, while the intent was to just get the absolute path. By using the `ABSOLUTE`, the bug is resolved.

[This](https://github.com/nlesc-recruit/ccglib/actions/runs/16348750322/job/46189530120) is a case where `REALPATH` fails, and [here](https://github.com/nlesc-recruit/ccglib/actions/runs/16350356739/job/46195248962) it works as it should with `ABSOLUTE`.

**Related issues**:

- N.A.

**Instructions to review the pull request**

- Check that `CHANGELOG.md` has been updated if necessary

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```
-->

<!--
Review online.
-->
