### PR TITLE
Don't overwrite CUDAWRAPPERS_COMPONENT if already set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,10 +52,12 @@ set(CUDAWRAPPERS_ALL_COMPONENTS cu cufft nvml nvrtc nvtx)
 set(CUDAWRAPPERS_MANDATORY_COMPONENTS cu)
 set(CUDAWRAPPERS_DEFAULT_COMPONENTS cu nvrtc)
 
-set(CUDAWRAPPERS_COMPONENTS
-    "${CUDAWRAPPERS_DEFAULT_COMPONENTS}"
-    CACHE STRING "List of components to build"
-)
+if(NOT DEFINED CUDAWRAPPERS_COMPONENTS)
+  set(CUDAWRAPPERS_COMPONENTS
+      "${CUDAWRAPPERS_DEFAULT_COMPONENTS}"
+      CACHE STRING "List of components to build"
+  )
+endif()
 
 # If 'all' is specified, set to all known components
 list(FIND CUDAWRAPPERS_COMPONENTS "all" _found)


### PR DESCRIPTION
**Description**

This is a follow-up for https://github.com/nlesc-recruit/cudawrappers/pull/344, it fixes the issue that cudawrappers' CMake sets the `CUDAWRAPPERS_COMPONENTS` variable even if it already exists. This causes the CMake configuration for external projects to fail because some targets may not exist. Making the initialization optional solves it.

For details see these pipeline runs: https://git.astron.nl/RD/pmt/-/merge_requests/117/pipelines

**Related issues**:

- N.A.

**Instructions to review the pull request**

- Check that `CHANGELOG.md` has been updated if necessary

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```
-->

<!--
Review online.
-->
