### PR TITLE
Only add build directory as include directory during build

### DIFF
--- a/cmake/cudawrappers-helper.cmake
+++ b/cmake/cudawrappers-helper.cmake
@@ -75,6 +75,8 @@ const std::string ${input_basename}_source = std::string(
 
   add_library(${input_basename} STATIC "${output_object_file}")
   set_target_properties(${input_basename} PROPERTIES LINKER_LANGUAGE CXX)
-  target_include_directories(${target_name} PUBLIC ${CMAKE_BINARY_DIR})
+  target_include_directories(
+    ${target_name} PUBLIC $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
+  )
   target_link_libraries(${target_name} PRIVATE ${input_basename})
 endfunction()


### PR DESCRIPTION
**Description**

Building the latest version of the [tensor-core-correlator](https://git.astron.nl/RD/tensor-core-correlator) doesn't work with the latest version of cudawrappers:

```
CMake Error in libtcc/CMakeLists.txt:
  Target "tcc" INTERFACE_INCLUDE_DIRECTORIES property contains path:

    "/home/veenboer/src/tensor-core-correlator/build"

  which is prefixed in the build directory.


CMake Error in libtcc/CMakeLists.txt:
  Target "tcc" INTERFACE_INCLUDE_DIRECTORIES property contains path:

    "/home/veenboer/src/tensor-core-correlator/build"

  which is prefixed in the build directory.Target "tcc"
  INTERFACE_INCLUDE_DIRECTORIES property contains path:

    "/home/veenboer/src/tensor-core-correlator/build"
```

This is triggered by this part of tcc's CMake:
```
install(
  TARGETS tcc
  EXPORT ${PROJECT_NAME}-config # export tcc cmake targets
  COMPONENT tcc
  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}
)
```

This is caused by an erroneous `target_include_directories` directive in cudawrappers's CMake that exposes the build directory in the install interface. The fix is simple: only use the include directory at build-time.


**Related issues**:

- N.A.

**Instructions to review the pull request**

- Check that `CHANGELOG.md` has been updated if necessary

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```
-->

<!--
Review online.
-->
