### PR TITLE
Link nvrtc target to dl library

### DIFF
--- a/cmake/cudawrappers-targets.cmake
+++ b/cmake/cudawrappers-targets.cmake
@@ -32,7 +32,7 @@ else()
     set(LINK_nvml CUDA::cuda_driver CUDA::nvml)
   endif()
   if(CUDAWRAPPERS_BUILD_NVRTC)
-    set(LINK_nvrtc CUDA::cuda_driver CUDA::nvrtc)
+    set(LINK_nvrtc CUDA::cuda_driver CUDA::nvrtc ${CMAKE_DL_LIBS})
   endif()
   # NVTX 3 is header only, so don't link nvToolsExt
   if(CUDAWRAPPERS_BUILD_NVTX AND NOT CUDAWRAPPERS_USE_NVTX3)


### PR DESCRIPTION
**Description**

Depending on the host compiler and possibly CUDA version, we need to link to the `ld` library for `dlopen` to be resolved.

**Related issues**:

- https://github.com/nlesc-recruit/cudawrappers/pull/354

**Instructions to review the pull request**

- Check that `CHANGELOG.md` has been updated if necessary

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```
-->

<!--
Review online.
-->
