### PR TITLE
Fix markdown link check CI workflow

### DIFF
--- a/.github/workflows/markdown-link-check.json
+++ b/.github/workflows/markdown-link-check.json
@@ -1,10 +1,12 @@
 {
-  "httpHeaders": [
+  "ignorePatterns": [
     {
-      "urls": ["https://*"],
-      "headers": {
-        "User-Agent": "Mozilla/5.0 ..."
-      }
+      "pattern": "^https://cppcheck\\.sourceforge\\.io",
+      "aliveStatusCodes": [200, 403]
+    },
+    {
+      "pattern": "^https://zenodo\\.org/records/",
+      "aliveStatusCodes": [200, 403]
     }
   ]
 }

--- a/.github/workflows/markdown-link-check.json
+++ b/.github/workflows/markdown-link-check.json
@@ -1,0 +1,10 @@
+{
+  "httpHeaders": [
+    {
+      "urls": ["https://*"],
+      "headers": {
+        "User-Agent": "Mozilla/5.0 ..."
+      }
+    }
+  ]
+}

--- a/.github/workflows/markdown-link-check.json
+++ b/.github/workflows/markdown-link-check.json
@@ -7,6 +7,10 @@
     {
       "pattern": "^https://zenodo\\.org/records/",
       "aliveStatusCodes": [200, 403]
+    },
+    {
+      "pattern": "^https://doxygen\\.nl/",
+      "aliveStatusCodes": [200, 403]
     }
   ]
 }

--- a/.github/workflows/markdown-link-check.json
+++ b/.github/workflows/markdown-link-check.json
@@ -5,7 +5,7 @@
       "aliveStatusCodes": [200, 403]
     },
     {
-      "pattern": "^https://zenodo\\.org/records/",
+      "pattern": "^https://zenodo\\.org/",
       "aliveStatusCodes": [200, 403]
     },
     {

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -24,4 +24,4 @@ jobs:
     - uses: actions/checkout@main
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
-        config-file: markdown-link-check.json
+        config-file: .github/workflows/markdown-link-check.json

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -23,3 +23,5 @@ jobs:
     steps:
     - uses: actions/checkout@main
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        config-file: markdown-link-check.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: v21.1.8
     hooks:
       - id: clang-format
-        exclude: macros.hpp
+        exclude: macros.hpp|\.json$
   - repo: https://github.com/pocc/pre-commit-hooks
     rev: v1.3.5
     hooks:


### PR DESCRIPTION
**Description**

The markdown-link-check is frequently failing. It appears that some requests are sometimes failing with a `403` error. This is now fixed by explicitly allowing `403` for the problematic urls. Somehow, pre-commit tries to run `clang-format` on the new `.json` file, so a small fix was needed in the pre-commit configuration file too.

**Related issues**:

- N.A.

**Instructions to review the pull request**

- Check that `CHANGELOG.md` has been updated if necessary

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/cudawrappers .
git checkout <this-branch>
cmake -S . -B build
make -C build
make -C build format # Nothing should change
make -C build lint # linting is broken until we fix the issues (see #92)
```
-->

<!--
Review online.
-->
